### PR TITLE
Add error handler and tidy logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,10 @@ from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 from src.config import TELEGRAM_TOKEN, ALLOWED_CHAT_IDS
 from src.handlers import get_handlers
 
+
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("telegram").setLevel(logging.WARNING)
 
 
 def allowed(chat_id: int) -> bool:
@@ -41,6 +44,12 @@ async def fake_ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
         name = "Неустановленный элемент"
     await update.message.reply_text(f"🚫 {name} отправлен(а) в объятия модерации... шутка 😉")
 
+async def on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    err = str(context.error)
+    if TELEGRAM_TOKEN:
+        err = err.replace(TELEGRAM_TOKEN, "[TOKEN]")
+    logging.exception("Unhandled exception: %s", err, exc_info=context.error)
+
 def build_app():
     app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
@@ -50,6 +59,7 @@ def build_app():
     app.add_handler(CommandHandler("ban", fake_ban))
     for h in get_handlers():
         app.add_handler(h)
+    app.add_error_handler(on_error)
     return app
 
 

--- a/src/handlers/trigger_handler.py
+++ b/src/handlers/trigger_handler.py
@@ -33,6 +33,7 @@ def _load_triggers() -> None:
         pattern = re.compile(rf"\b{re.escape(phrase)}\b", flags=re.IGNORECASE)
         patterns.append((pattern, reply))
     _TRIGGER_PATTERNS = patterns
+    logging.info("Loaded %d triggers", len(_TRIGGER_PATTERNS))
 
 _load_triggers()
 


### PR DESCRIPTION
## Summary
- configure logging to reduce httpx and telegram noise
- add global error handler that sanitizes token
- log trigger count when loading configuration

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76472ddd0832b9919d56573cc1c8e