### PR TITLE
refactor: simplify GPT handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,15 @@ async def on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
         err = err.replace(TELEGRAM_TOKEN, "[TOKEN]")
     if OPENAI_API_KEY:
         err = err.replace(OPENAI_API_KEY, "[KEY]")
-    logging.exception("Unhandled exception: %s", err, exc_info=context.error)
+    # Sanitize stack trace as well
+    import traceback
+
+    tb = "".join(traceback.format_exception(type(context.error), context.error, context.error.__traceback__))
+    if TELEGRAM_TOKEN:
+        tb = tb.replace(TELEGRAM_TOKEN, "[TOKEN]")
+    if OPENAI_API_KEY:
+        tb = tb.replace(OPENAI_API_KEY, "[KEY]")
+    logging.error("Unhandled exception: %s\n%s", err, tb)
 
 def build_app():
     app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()

--- a/src/handlers/gpt_handler.py
+++ b/src/handlers/gpt_handler.py
@@ -33,32 +33,9 @@ async def cmd_help(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     text = (
         "Использование GPT:\n"
         " .<вопрос> — быстрый ответ (gpt-4o-mini, до 400 токенов)\n"
-        " ..<вопрос> — подробный ответ (gpt-4o, до 600 токенов)\n"
-        " /ask <вопрос> — то же, что '.'; если текст начинается с '..', то полный режим\n"
-        "\nПрочее:\n"
-        " /coin — орёл/решка\n"
-        " /8ball — магический шар\n"
-        " /ban — фейк-бан"
+        " ..<вопрос> — подробный ответ (gpt-4o, до 600 токенов)"
     )
     await update.message.reply_text(text)
-
-
-async def cmd_ask(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
-    """Handle /ask command."""
-    if not _allowed(update.effective_chat.id):
-        return
-    text = " ".join(ctx.args).strip()
-    if not text:
-        await update.message.reply_text("Использование: /ask <вопрос>")
-        return
-    model = OPENAI_MODEL
-    max_tokens = OPENAI_MAX_OUTPUT_TOKENS
-    if text.startswith(".."):
-        model = OPENAI_MODEL_FULL
-        max_tokens = OPENAI_MAX_OUTPUT_TOKENS_FULL
-        text = text[2:].lstrip()
-    update.message.text = text
-    await ask(update, ctx, model, max_tokens)
 
 async def handle_message(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if not _allowed(update.effective_chat.id):
@@ -108,6 +85,11 @@ async def ask(
     msg = await update.message.reply_text("Думаю… ⏳")
     try:
         answer = await ask_gpt(prompt, model=model, max_tokens=max_tokens)
+        if not answer.strip():
+            await update.message.reply_text(
+                "⚠️ GPT вернул пустой ответ. Попробуй снова или переформулируй."
+            )
+            return
         log.info("response_len=%d", len(answer))
         _chat_context[chat_id].append(f"Q: {user_q}")
         _chat_context[chat_id].append(f"A: {answer[:500]}")
@@ -126,6 +108,8 @@ async def ask(
 def get_handlers():
     return [
         CommandHandler("help", cmd_help),
-        CommandHandler("ask", cmd_ask),
-        MessageHandler(filters.TEXT & (~filters.COMMAND), handle_message),
+        MessageHandler(
+            filters.TEXT & (~filters.COMMAND) & filters.Regex(r'^\.'),
+            handle_message,
+        ),
     ]

--- a/src/handlers/trigger_handler.py
+++ b/src/handlers/trigger_handler.py
@@ -45,7 +45,7 @@ async def trigger_reply(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     if ALLOWED_CHAT_IDS and update.effective_chat.id not in ALLOWED_CHAT_IDS:
         return
     text = update.message.text or ""
-    if not text or text.startswith('.') or text.startswith('/'):
+    if not text:
         return
     for pattern, reply in _TRIGGER_PATTERNS:
         if pattern.search(text):
@@ -54,5 +54,8 @@ async def trigger_reply(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
 def get_handlers():
     return [
-        MessageHandler(filters.TEXT & (~filters.COMMAND), trigger_reply)
+        MessageHandler(
+            filters.TEXT & (~filters.Regex(r'^[./]')),
+            trigger_reply,
+        )
     ]


### PR DESCRIPTION
## Summary
- drop /ask command and limit GPT triggers to leading dots
- add async GPT client with Responses fallback to Chat Completions
- sanitize secrets in error logs

## Testing
- `python -m py_compile MyTG_BOT/src/gpt_client.py MyTG_BOT/src/handlers/gpt_handler.py MyTG_BOT/src/handlers/trigger_handler.py MyTG_BOT/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a777cd4908832bbd6158900199e320