### PR TITLE
Refactor GPT handler with diagnostics and logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,34 @@
 import logging
 import random
+import platform
+import telegram
+import openai
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
-from src.config import TELEGRAM_TOKEN, ALLOWED_CHAT_IDS, OPENAI_API_KEY
+
+from src.config import (
+    TELEGRAM_TOKEN,
+    ALLOWED_CHAT_IDS,
+    OPENAI_API_KEY,
+    OPENAI_MODEL,
+    OPENAI_MODEL_FULL,
+    OPENAI_MAX_OUTPUT_TOKENS,
+    OPENAI_MAX_OUTPUT_TOKENS_FULL,
+    LOG_LEVEL,
+)
+from src.config import config_info
 from src.handlers import get_handlers
+from src.handlers.gpt_handler import gpt_handler_info
+from src.handlers.trigger_handler import triggers_info
+from src.gpt_client import client_diagnostics
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,
+)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("telegram").setLevel(logging.WARNING)
 
@@ -45,19 +67,26 @@ async def fake_ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(f"🚫 {name} отправлен(а) в объятия модерации... шутка 😉")
 
 async def on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    def _mask(value: str | None) -> str:
+        return value[:4] + "…" + value[-4:] if value else ""
+
     err = str(context.error)
     if TELEGRAM_TOKEN:
-        err = err.replace(TELEGRAM_TOKEN, "[TOKEN]")
+        err = err.replace(TELEGRAM_TOKEN, _mask(TELEGRAM_TOKEN))
     if OPENAI_API_KEY:
-        err = err.replace(OPENAI_API_KEY, "[KEY]")
+        err = err.replace(OPENAI_API_KEY, _mask(OPENAI_API_KEY))
     # Sanitize stack trace as well
     import traceback
 
-    tb = "".join(traceback.format_exception(type(context.error), context.error, context.error.__traceback__))
+    tb = "".join(
+        traceback.format_exception(
+            type(context.error), context.error, context.error.__traceback__
+        )
+    )
     if TELEGRAM_TOKEN:
-        tb = tb.replace(TELEGRAM_TOKEN, "[TOKEN]")
+        tb = tb.replace(TELEGRAM_TOKEN, _mask(TELEGRAM_TOKEN))
     if OPENAI_API_KEY:
-        tb = tb.replace(OPENAI_API_KEY, "[KEY]")
+        tb = tb.replace(OPENAI_API_KEY, _mask(OPENAI_API_KEY))
     logging.error("Unhandled exception: %s\n%s", err, tb)
 
 def build_app():
@@ -73,8 +102,31 @@ def build_app():
     return app
 
 
+def startup_diagnostics() -> None:
+    log = logging.getLogger("startup")
+    log.info(
+        "Python=%s PTB=%s OpenAI=%s",
+        platform.python_version(),
+        telegram.__version__,
+        openai.__version__,
+    )
+    log.info(
+        "Models mini=%s(%d) full=%s(%d)",
+        OPENAI_MODEL,
+        OPENAI_MAX_OUTPUT_TOKENS,
+        OPENAI_MODEL_FULL,
+        OPENAI_MAX_OUTPUT_TOKENS_FULL,
+    )
+    log.info("Allowed chats: %s", ALLOWED_CHAT_IDS or "all")
+    log.info("Triggers loaded: %d", triggers_info())
+    log.info("GPT handler: %s", gpt_handler_info())
+    log.info("Config: %s", config_info())
+    client_diagnostics()
+
+
 if __name__ == "__main__":
     app = build_app()
+    startup_diagnostics()
     # Если получаете ошибку "Conflict: terminated by other",
     # убедитесь, что запущен только один инстанс бота.
     app.run_polling(drop_pending_updates=True)

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,16 @@
 import os
-from typing import Set
+from typing import Set, Dict, Any
+
 
 def _csv_to_int_set(s: str) -> Set[int]:
     return {int(x) for x in s.split(",") if x.strip()} if s else set()
+
+
+def _mask(value: str | None) -> str:
+    if not value:
+        return ""
+    return value[:4] + "…" + value[-4:]
+
 
 TELEGRAM_TOKEN = os.environ["TELEGRAM_TOKEN"]
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -16,3 +24,22 @@ MAX_REPLY_CHARS = int(os.getenv("MAX_REPLY_CHARS", "3500"))
 CONTEXT_TURNS = int(os.getenv("CONTEXT_TURNS", "5"))
 COOLDOWN_SECONDS = float(os.getenv("COOLDOWN_SECONDS", "3"))
 ALLOWED_CHAT_IDS = _csv_to_int_set(os.getenv("ALLOWED_CHAT_IDS", ""))
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
+
+def config_info() -> Dict[str, Any]:
+    """Return diagnostic information about configuration."""
+
+    return {
+        "OPENAI_MODEL": OPENAI_MODEL,
+        "OPENAI_MODEL_FULL": OPENAI_MODEL_FULL,
+        "OPENAI_MAX_OUTPUT_TOKENS": OPENAI_MAX_OUTPUT_TOKENS,
+        "OPENAI_MAX_OUTPUT_TOKENS_FULL": OPENAI_MAX_OUTPUT_TOKENS_FULL,
+        "CONTEXT_TURNS": CONTEXT_TURNS,
+        "COOLDOWN_SECONDS": COOLDOWN_SECONDS,
+        "ALLOWED_CHAT_IDS": list(ALLOWED_CHAT_IDS),
+        "OPENAI_API_KEY": bool(OPENAI_API_KEY),
+        "TELEGRAM_TOKEN": _mask(TELEGRAM_TOKEN),
+        "LOG_LEVEL": LOG_LEVEL,
+    }

--- a/src/gpt_client.py
+++ b/src/gpt_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import openai
 from openai import OpenAI
 
 from .config import OPENAI_API_KEY, OPENAI_MODEL, OPENAI_MAX_OUTPUT_TOKENS
@@ -78,4 +79,24 @@ async def ask_gpt(
 
     # The SDK is synchronous, run it in a background thread to avoid blocking
     return await asyncio.to_thread(_call)
+
+
+def client_diagnostics() -> dict[str, object]:
+    """Log and return diagnostic info about the OpenAI client."""
+
+    client = _get_client()
+    info = {
+        "sdk_version": openai.__version__,
+        "api_key": bool(OPENAI_API_KEY),
+        "responses_api": hasattr(client, "responses"),
+        "chat_completions_api": hasattr(getattr(client, "chat", None), "completions"),
+    }
+    log.info(
+        "OpenAI SDK %s key=%s responses=%s chat_completions=%s",
+        info["sdk_version"],
+        _mask(OPENAI_API_KEY),
+        info["responses_api"],
+        info["chat_completions_api"],
+    )
+    return info
 

--- a/src/handlers/trigger_handler.py
+++ b/src/handlers/trigger_handler.py
@@ -59,3 +59,9 @@ def get_handlers():
             trigger_reply,
         )
     ]
+
+
+def triggers_info() -> int:
+    """Return number of loaded triggers."""
+
+    return len(_TRIGGER_PATTERNS)


### PR DESCRIPTION
## Summary
- replace /ask with dot-prefixed GPT questions
- add OpenAI client diagnostics and startup logs
- improve GPT handler logging, cooldown, and empty-response warnings

## Testing
- `python -m py_compile main.py src/config.py src/gpt_client.py src/handlers/gpt_handler.py src/handlers/trigger_handler.py`
- `TELEGRAM_TOKEN=123:ABC OPENAI_API_KEY=sk-test LOG_LEVEL=INFO python - <<'PY'
from main import startup_diagnostics
startup_diagnostics()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a77cb1a700832b817a75db353a3d68