### PR TITLE
feat: add logging config and error handler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ MAX_TOKENS_DOT=400
 MAX_TOKENS_DDOT=600
 
 PORT=8080
+
+# logging
+LOG_CHAT_ID=
+LOG_FORMAT=plain  # или json

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import logging
+import uuid
+import json
 from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
 from src.config import config
@@ -27,27 +29,56 @@ async def _post_init(app: Application) -> None:
             logging.error("webhook set err %s", mask(str(e)))
 
 
+def _make_logger():
+    if config.LOG_FORMAT == "json":
+        class JsonFormatter(logging.Formatter):
+            def format(self, record):
+                log_record = {
+                    "level": record.levelname,
+                    "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+                    "name": record.name,
+                    "message": record.getMessage(),
+                }
+                if record.exc_info:
+                    log_record["exc_info"] = self.formatException(record.exc_info)
+                return json.dumps(log_record, ensure_ascii=False)
+        handler = logging.StreamHandler()
+        handler.setFormatter(JsonFormatter())
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.addHandler(handler)
+        root.setLevel(logging.INFO)
+    else:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+        )
+
+
+async def on_error(update, context):
+    rid = str(uuid.uuid4())[:8]
+    logging.exception("Unhandled error [%s]: %s", rid, context.error)
+    try:
+        if update and getattr(update, "effective_chat", None):
+            await context.bot.send_message(update.effective_chat.id, f"⚠️ Ошибка (id={rid}). Попробуй ещё раз.")
+        if config.LOG_CHAT_ID:
+            await context.bot.send_message(config.LOG_CHAT_ID, f"❌ Error {rid}: {context.error}")
+    except Exception:
+        pass
+
+
 def main() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
-    )
+    _make_logger()
     app = Application.builder().token(config.TELEGRAM_TOKEN).post_init(_post_init).build()
 
     app.add_handler(CommandHandler("start", start_handler))
     app.add_handler(CommandHandler("id", id_handler))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, gpt_handler))
 
-    async def on_error(update, context):
-        logging.exception("Unhandled error: %s", context.error)
-        # Дружелюбное уведомление пользователю, если есть контекст чата
-        try:
-            if update and getattr(update, "effective_chat", None):
-                await context.bot.send_message(update.effective_chat.id, "⚠️ Произошла ошибка. Попробуй ещё раз.")
-        except Exception:
-            pass
-
     app.add_error_handler(on_error)
+
+    logging.info("config ok: webhook=%s require_prefix=%s", 
+                 bool(config.WEBHOOK_URL and config.WEBHOOK_SECRET), config.REQUIRE_PREFIX)
 
     if config.WEBHOOK_URL and config.WEBHOOK_SECRET and app.bot_data.get("webhook_ok") is True:
         logging.info("webhook mode")

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,10 @@ class Settings(BaseModel):
     # Behavior
     REQUIRE_PREFIX: bool = os.getenv("REQUIRE_PREFIX", "true").lower() in ("1", "true", "yes")
 
+    # Logging
+    LOG_CHAT_ID: int | None = int(os.getenv("LOG_CHAT_ID")) if os.getenv("LOG_CHAT_ID") else None
+    LOG_FORMAT: str = os.getenv("LOG_FORMAT", "plain")  # plain|json
+
     # Budget / abuse protection
     RATE_LIMIT_PER_CHAT: int = int(os.getenv("RATE_LIMIT_PER_CHAT", 5))   # N запросов
     RATE_LIMIT_INTERVAL: int = int(os.getenv("RATE_LIMIT_INTERVAL", 60))  # окно секунд


### PR DESCRIPTION
## Summary
- support selectable plain or JSON logging
- notify users and log chat on unhandled errors
- document LOG_CHAT_ID and LOG_FORMAT env vars
- trace GPT requests with per-request IDs and timing logs

## Testing
- `python -m py_compile main.py src/config.py src/handlers/gpt_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68a80058cbd4832bbf23f6e2f1ee1411