### PR TITLE
Improve environment config handling

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,9 +4,22 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+def _first_nonempty(*names: str) -> str | None:
+    """Верни первое непустое значение env (обрезая пробелы). Поддержи алиасы."""
+    for n in names:
+        v = os.getenv(n)
+        if v and v.strip():
+            return v.strip()
+    return None
+
+# Критичные ключи читаем ДО инициализации pydantic-модели
+_raw_telegram = _first_nonempty("TELEGRAM_TOKEN", "BOT_TOKEN", "TELEGRAM_BOT_TOKEN")
+_raw_openai   = _first_nonempty("OPENAI_API_KEY", "OPENAI_KEY")
+
 class Settings(BaseModel):
-    TELEGRAM_TOKEN: str = Field(..., min_length=10)
-    OPENAI_API_KEY: str = Field(..., min_length=10)
+    # ВАЖНО: подставь значения env прямо в Field(...)
+    TELEGRAM_TOKEN: str = Field(_raw_telegram or ..., min_length=10)
+    OPENAI_API_KEY: str = Field(_raw_openai   or ..., min_length=10)
 
     # Network / webhook
     PORT: int = int(os.getenv("PORT", 8080))
@@ -27,17 +40,26 @@ class Settings(BaseModel):
     LOG_FORMAT: str = os.getenv("LOG_FORMAT", "plain")  # plain|json
 
     # Budget / abuse protection
-    RATE_LIMIT_PER_CHAT: int = int(os.getenv("RATE_LIMIT_PER_CHAT", 5))   # N запросов
-    RATE_LIMIT_INTERVAL: int = int(os.getenv("RATE_LIMIT_INTERVAL", 60))  # окно секунд
-    MAX_PROMPT_CHARS: int = int(os.getenv("MAX_PROMPT_CHARS", 4000))      # макс. длина входа
-    MAX_REPLY_CHARS: int = int(os.getenv("MAX_REPLY_CHARS", 3500))        # макс. длина ответа в сообщении
+    RATE_LIMIT_PER_CHAT: int = int(os.getenv("RATE_LIMIT_PER_CHAT", 5))
+    RATE_LIMIT_INTERVAL: int = int(os.getenv("RATE_LIMIT_INTERVAL", 60))
+    MAX_PROMPT_CHARS: int = int(os.getenv("MAX_PROMPT_CHARS", 4000))
+    MAX_REPLY_CHARS: int = int(os.getenv("MAX_REPLY_CHARS", 3500))
 
 try:
-    # минимальная валидация диапазонов
+    # Мини-валидация диапазонов + понятная диагностика
     config = Settings()
     assert config.RATE_LIMIT_PER_CHAT > 0
     assert config.RATE_LIMIT_INTERVAL > 0
     assert config.MAX_PROMPT_CHARS > 0
-    assert 1000 <= config.MAX_REPLY_CHARS <= 4000  # телеграм ~4096, с запасом под html
+    assert 1000 <= config.MAX_REPLY_CHARS <= 4000  # телега ~4096, оставляем запас под HTML
 except (ValidationError, AssertionError) as e:
+    missing = []
+    if not _raw_telegram:
+        missing.append("TELEGRAM_TOKEN (или BOT_TOKEN/TELEGRAM_BOT_TOKEN)")
+    if not _raw_openai:
+        missing.append("OPENAI_API_KEY (или OPENAI_KEY)")
+    if missing:
+        print("❌ Отсутствуют переменные окружения:", ", ".join(missing))
+        print("   • Railway: Settings → Variables (значения БЕЗ кавычек).")
+        print("   • Локально: .env рядом с main.py (НЕ .env.example).")
     raise SystemExit(f"Invalid config: {e}")


### PR DESCRIPTION
## Summary
- load TELEGRAM_TOKEN and OPENAI_API_KEY from environment aliases
- add friendly diagnostics for missing config variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a803e2fa24832bb9b61b0d2199b6c5