### PR TITLE
fix telegram html parsing

### DIFF
--- a/src/utils/format.py
+++ b/src/utils/format.py
@@ -2,6 +2,12 @@ import html
 
 
 def as_html(text: str) -> str:
-    """Escape text for safe HTML parse_mode and preserve line breaks."""
-    return html.escape(text).replace("\n", "<br>")
+    """
+    Экранируем текст для parse_mode="HTML".
+    Telegram НЕ поддерживает <br>, поэтому сохраняем переносы как '\n'.
+    """
+    if text is None:
+        return ""
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return html.escape(text)
 


### PR DESCRIPTION
## Summary
- keep newlines instead of `<br>` when escaping HTML
- fallback to plain text if Telegram rejects HTML messages
- ensure chunking always yields at least one message and handle missing initial message

## Testing
- `pytest >/tmp/unit_test.log && tail -n 20 /tmp/unit_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a8061d7660832b8502a0387c525341