### PR TITLE
Add dialog history context to GPT requests

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -34,6 +34,7 @@ class Settings(BaseModel):
 
     # Behavior
     REQUIRE_PREFIX: bool = os.getenv("REQUIRE_PREFIX", "true").lower() in ("1", "true", "yes")
+    DIALOG_HISTORY_LEN: int = int(os.getenv("DIALOG_HISTORY_LEN", 5))
 
     # Logging
     LOG_CHAT_ID: int | None = int(os.getenv("LOG_CHAT_ID")) if os.getenv("LOG_CHAT_ID") else None
@@ -52,6 +53,7 @@ try:
     assert config.RATE_LIMIT_INTERVAL > 0
     assert config.MAX_PROMPT_CHARS > 0
     assert 1000 <= config.MAX_REPLY_CHARS <= 4000  # телега ~4096, оставляем запас под HTML
+    assert config.DIALOG_HISTORY_LEN > 0
 except (ValidationError, AssertionError) as e:
     missing = []
     if not _raw_telegram:


### PR DESCRIPTION
## Summary
- add `DIALOG_HISTORY_LEN` setting to configure per-chat dialog memory
- track recent user/assistant exchanges and include them in GPT prompt
- trim dialog history and user message so prompt respects `MAX_PROMPT_CHARS`

## Testing
- `python -m py_compile src/config.py src/handlers/gpt_handler.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80dc4c7c8832b8f07c08df00fa283