### PR TITLE
Add Groq support and provider switch via prefixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Антиспам отключён и не поддерживается.
 TELEGRAM_TOKEN=123:ABC
-OPENAI_API_KEY=sk-...
+OPENAI_API_KEY=
+GROQ_API_KEY=
 
 # webhook
 WEBHOOK_URL=
@@ -14,6 +15,8 @@ REQUIRE_PREFIX=true
 # модели/токены
 MODEL_DOT=gpt-4o-mini
 MODEL_DDOT=gpt-4o
+GROQ_MODEL=llama-3.3-70b-versatile
+MAX_TOKENS_GROQ=800
 MAX_TOKENS_DOT=800
 MAX_TOKENS_DDOT=2000
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .env
+.env.*
+*.env
+/secrets/*
 __pycache__/
 *.pyc
 *.pyo
 *.pyd
-.env.*
 .venv/
 venv/
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # MyTG_BOT
 
-Телеграм-бот, отвечающий на сообщения с помощью OpenAI.
+Телеграм-бот, отвечающий на сообщения с помощью OpenAI и Groq.
 
 ## Режимы запроса (`.` и `..`)
-- `.` — короткий режим: используется `MODEL_DOT`, ответ ограничен `MAX_TOKENS_DOT` токенами.
-- `..` — полный режим: используется `MODEL_DDOT`, ответ ограничен `MAX_TOKENS_DDOT` токенами.
-- Если `REQUIRE_PREFIX=false`, точка не обязательна и короткий режим используется по умолчанию.
+- `. вопрос` — Groq LLaMA-3-70B в стиле матершинника.
+- `.. вопрос` — OpenAI GPT-4o, отвечает вежливо и структурированно.
+- Если `REQUIRE_PREFIX=false`, точка не обязательна и по умолчанию используется Groq.
 
 ## Переменные окружения
 | Переменная | Назначение |
 | --- | --- |
 | `TELEGRAM_TOKEN` | токен бота |
 | `OPENAI_API_KEY` | ключ OpenAI |
+| `GROQ_API_KEY` | ключ Groq |
 | `WEBHOOK_URL` | URL вебхука (опц.) |
 | `WEBHOOK_SECRET` | секрет вебхука (опц.) |
 | `PORT` | порт вебсервера |
-| `MODEL_DOT` | модель для короткого режима |
-| `MODEL_DDOT` | модель для полного режима |
-| `MAX_TOKENS_DOT` | предел токенов для короткого режима |
-| `MAX_TOKENS_DDOT` | предел токенов для полного режима |
+| `MODEL_DOT` | модель OpenAI для короткого режима |
+| `MODEL_DDOT` | модель OpenAI для полного режима |
+| `GROQ_MODEL` | модель Groq |
+| `MAX_TOKENS_GROQ` | предел токенов для Groq |
+| `MAX_TOKENS_DOT` | предел токенов для короткого режима OpenAI |
+| `MAX_TOKENS_DDOT` | предел токенов для полного режима OpenAI |
 | `MAX_PROMPT_CHARS` | максимальная длина входного сообщения |
 | `MAX_REPLY_CHARS` | максимальная длина ответа |
 | `REQUIRE_PREFIX` | требовать ли префикс `.`/`..` |
@@ -27,3 +30,24 @@
 | `LOG_FORMAT` | формат логов: `plain` или `json` |
 
 Антиспам отключён и не поддерживается.
+
+## Безопасность
+⚠️ Никогда не храните ключи в коде или репозитории. Используйте только переменные окружения (Railway → Settings → Variables или локальный `.env`).
+
+## Пример запуска
+
+```bash
+docker run \
+  -e TELEGRAM_TOKEN=123:ABC \
+  -e OPENAI_API_KEY=your-openai-key \
+  -e GROQ_API_KEY=your-groq-key \
+  mytg_bot:latest
+```
+
+На Railway переменные задаются в разделе **Settings → Variables**:
+
+```
+TELEGRAM_TOKEN=123:ABC
+OPENAI_API_KEY=your-openai-key
+GROQ_API_KEY=your-groq-key
+```

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from telegram.ext import Application, CommandHandler, MessageHandler, filters
 
 from src.config import config
 from src.handlers.gpt_handler import gpt_handler, id_handler, start_handler
+from src.utils.text_utils import mask
 
 
 def _make_logger():
@@ -38,7 +39,7 @@ def _make_logger():
 
 async def on_error(update, context):
     rid = str(uuid.uuid4())[:8]
-    logging.exception("Unhandled error [%s]: %s", rid, context.error)
+    logging.exception("Unhandled error [%s]: %s", rid, mask(str(context.error)))
     try:
         if update and getattr(update, "effective_chat", None):
             await context.bot.send_message(
@@ -46,7 +47,7 @@ async def on_error(update, context):
             )
         if config.LOG_CHAT_ID:
             await context.bot.send_message(
-                config.LOG_CHAT_ID, f"❌ Error {rid}: {context.error}"
+                config.LOG_CHAT_ID, f"❌ Error {rid}: {mask(str(context.error))}"
             )
     except Exception:
         pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot==21.4
 openai>=1.100.0,<2
 python-dotenv>=1.0.1
 pydantic>=2.8
+requests>=2.31

--- a/src/config.py
+++ b/src/config.py
@@ -18,12 +18,14 @@ def _first_nonempty(*names: str) -> str | None:
 # Критичные ключи читаем ДО инициализации pydantic-модели
 _raw_telegram = _first_nonempty("TELEGRAM_TOKEN", "BOT_TOKEN", "TELEGRAM_BOT_TOKEN")
 _raw_openai = _first_nonempty("OPENAI_API_KEY", "OPENAI_KEY")
+_raw_groq = _first_nonempty("GROQ_API_KEY", "GROQ_KEY")
 
 
 class Settings(BaseModel):
     # ВАЖНО: подставь значения env прямо в Field(...)
     TELEGRAM_TOKEN: str = Field(_raw_telegram or ..., min_length=10)
-    OPENAI_API_KEY: str = Field(_raw_openai or ..., min_length=10)
+    OPENAI_API_KEY: str | None = Field(_raw_openai, min_length=10)
+    GROQ_API_KEY: str | None = Field(_raw_groq, min_length=10)
 
     # Network / webhook
     PORT: int = int(os.getenv("PORT", 8080))
@@ -33,6 +35,8 @@ class Settings(BaseModel):
     # Models / limits
     MODEL_DOT: str = os.getenv("MODEL_DOT", "gpt-4o-mini")
     MODEL_DDOT: str = os.getenv("MODEL_DDOT", "gpt-4o")
+    GROQ_MODEL: str = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
+    MAX_TOKENS_GROQ: int = int(os.getenv("MAX_TOKENS_GROQ", 400))
     MAX_TOKENS_DOT: int = int(os.getenv("MAX_TOKENS_DOT", 400))
     MAX_TOKENS_DDOT: int = int(os.getenv("MAX_TOKENS_DDOT", 600))
 
@@ -67,8 +71,6 @@ except (ValidationError, AssertionError) as e:
     missing = []
     if not _raw_telegram:
         missing.append("TELEGRAM_TOKEN (или BOT_TOKEN/TELEGRAM_BOT_TOKEN)")
-    if not _raw_openai:
-        missing.append("OPENAI_API_KEY (или OPENAI_KEY)")
     if missing:
         print("❌ Отсутствуют переменные окружения:", ", ".join(missing))
         print("   • Railway: Settings → Variables (значения БЕЗ кавычек).")

--- a/src/gpt_client.py
+++ b/src/gpt_client.py
@@ -1,46 +1,49 @@
 import asyncio
 import logging
+import os
 
+import requests
 from openai import OpenAI
 
 from src.utils.text_utils import mask
 
 _client: OpenAI | None = None
-_client_key: str | None = None
+_client_token: str | None = None
 
 
-def _get_client(api_key: str) -> OpenAI:
-    global _client, _client_key
-    if _client is None or _client_key != api_key:
-        _client = OpenAI(api_key=api_key)
-        _client_key = api_key
+def _get_client(api_token: str) -> OpenAI:
+    global _client, _client_token
+    if _client is None or _client_token != api_token:
+        os.environ["OPENAI_API_KEY"] = api_token
+        _client = OpenAI()
+        _client_token = api_token
     return _client
 
 
-async def ask_gpt(
+async def ask_openai(
     *,
-    api_key: str,
+    api_token: str,
     model: str,
     prompt: str,
     max_tokens: int,
-    system: str = "Отвечай кратко и по делу для телеграм-чата.",
+    system: str,
     timeout: int = 30,
 ) -> str:
     def _request() -> str:
-        client = _get_client(api_key)
+        client = _get_client(api_token)
         text = ""
         try:
             resp = client.responses.create(
                 model=model,
                 input=prompt,
-                instructions=system,  # Responses API ждёт 'instructions'
+                instructions=system,
                 max_output_tokens=max_tokens,
             )
             text = getattr(resp, "output_text", "") or ""
             if not text:
                 text = resp.output[0].content[0].text
         except Exception as e:
-            logging.warning("responses err %s", mask(str(e)))
+            logging.warning("[openai] responses error %s", mask(str(e)))
         if not text:
             try:
                 resp = client.chat.completions.create(
@@ -53,12 +56,56 @@ async def ask_gpt(
                 )
                 text = resp.choices[0].message.content
             except Exception as e:
-                logging.error("chat err %s", mask(str(e)))
+                logging.error("[openai] chat error %s", mask(str(e)))
                 text = ""
         return text
 
     try:
         return await asyncio.wait_for(asyncio.to_thread(_request), timeout)
     except Exception as e:
-        logging.error("gpt timeout err %s", mask(str(e)))
+        logging.error("[openai] timeout %s", mask(str(e)))
+        return ""
+
+
+async def ask_groq(
+    *,
+    api_token: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    system: str,
+    timeout: int = 30,
+) -> str:
+    url = "https://api.groq.com/openai/v1/chat/completions"
+
+    def _request() -> str:
+        try:
+            resp = requests.post(
+                url,
+                headers={"Authorization": f"Bearer {api_token}"},
+                json={
+                    "model": model,
+                    "messages": [
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": prompt},
+                    ],
+                    "max_tokens": max_tokens,
+                },
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            choice = data.get("choices", [{}])[0]
+            content = choice.get("message", {}).get("content")
+            if not content:
+                content = choice.get("delta", {}).get("content", "")
+            return content or ""
+        except Exception as e:
+            logging.error("[groq] error %s", mask(str(e)))
+            return ""
+
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(_request), timeout)
+    except Exception as e:
+        logging.error("[groq] timeout %s", mask(str(e)))
         return ""


### PR DESCRIPTION
## Summary
- move all API credentials to environment variables and document secret handling
- mask sensitive data in logs and warn when provider keys are missing
- add requests dependency and ignore env/secret files in git
- send every response chunk as its own message to avoid partial edits
- document security practices for API keys

## Testing
- `python -m py_compile src/config.py src/gpt_client.py src/handlers/gpt_handler.py main.py`
- `grep -R -n -E "(sk-|gsk_|api[_-]?key|Authorization:\s*Bearer)" . || true`
- `rg edit_text`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc2e6204832bb75de47253831121