### PR TITLE
fix(prefix): correct routing order for '..' vs '.' + respect REQUIRE_PREFIX/DEFAULT_PROVIDER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,14 +10,13 @@ WEBHOOK_SECRET=
 # лимиты
 MAX_PROMPT_CHARS=4000
 MAX_REPLY_CHARS=3500
-REQUIRE_PREFIX=true
+REQUIRE_PREFIX=false     # true: требовать '.' или '..' в начале сообщения
+DEFAULT_PROVIDER=groq    # groq | openai — что использовать без префикса
 
 # модели/токены
-MODEL_DOT=gpt-4o-mini
 MODEL_DDOT=gpt-4o
 GROQ_MODEL=llama-3.3-70b-versatile
 MAX_TOKENS_GROQ=800
-MAX_TOKENS_DOT=800
 MAX_TOKENS_DDOT=2000
 
 PORT=8080

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## Режимы запроса (`.` и `..`)
 - `. вопрос` — Groq LLaMA-3-70B в стиле матершинника.
 - `.. вопрос` — OpenAI GPT-4o, отвечает вежливо и структурированно.
-- Если `REQUIRE_PREFIX=false`, точка не обязательна и по умолчанию используется Groq.
+- Если `REQUIRE_PREFIX=false`, префикс не обязателен. В этом случае используется провайдер из переменной
+<code>DEFAULT_PROVIDER</code> (<code>groq</code> или <code>openai</code>). По умолчанию — <code>groq</code>.
 
 ## Переменные окружения
 | Переменная | Назначение |
@@ -16,15 +17,14 @@
 | `WEBHOOK_URL` | URL вебхука (опц.) |
 | `WEBHOOK_SECRET` | секрет вебхука (опц.) |
 | `PORT` | порт вебсервера |
-| `MODEL_DOT` | модель OpenAI для короткого режима |
-| `MODEL_DDOT` | модель OpenAI для полного режима |
+| `MODEL_DDOT` | модель OpenAI |
 | `GROQ_MODEL` | модель Groq |
 | `MAX_TOKENS_GROQ` | предел токенов для Groq |
-| `MAX_TOKENS_DOT` | предел токенов для короткого режима OpenAI |
-| `MAX_TOKENS_DDOT` | предел токенов для полного режима OpenAI |
+| `MAX_TOKENS_DDOT` | предел токенов для OpenAI |
 | `MAX_PROMPT_CHARS` | максимальная длина входного сообщения |
 | `MAX_REPLY_CHARS` | максимальная длина ответа |
 | `REQUIRE_PREFIX` | требовать ли префикс `.`/`..` |
+| `DEFAULT_PROVIDER` | провайдер по умолчанию без префикса: `groq` или `openai` |
 | `DIALOG_HISTORY_LEN` | сколько пар реплик хранить в истории |
 | `LOG_CHAT_ID` | чат для логов (опц.) |
 | `LOG_FORMAT` | формат логов: `plain` или `json` |

--- a/src/config.py
+++ b/src/config.py
@@ -33,18 +33,24 @@ class Settings(BaseModel):
     WEBHOOK_SECRET: str | None = os.getenv("WEBHOOK_SECRET") or None
 
     # Models / limits
-    MODEL_DOT: str = os.getenv("MODEL_DOT", "gpt-4o-mini")
     MODEL_DDOT: str = os.getenv("MODEL_DDOT", "gpt-4o")
     GROQ_MODEL: str = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
     MAX_TOKENS_GROQ: int = int(os.getenv("MAX_TOKENS_GROQ", 400))
-    MAX_TOKENS_DOT: int = int(os.getenv("MAX_TOKENS_DOT", 400))
     MAX_TOKENS_DDOT: int = int(os.getenv("MAX_TOKENS_DDOT", 600))
 
     # Behavior
-    REQUIRE_PREFIX: bool = os.getenv("REQUIRE_PREFIX", "true").lower() in (
-        "1",
-        "true",
-        "yes",
+    REQUIRE_PREFIX: bool = Field(
+        os.getenv("REQUIRE_PREFIX", "false").lower()
+        in (
+            "1",
+            "true",
+            "yes",
+        ),
+        description="Если true, пользователю нужен префикс '.' или '..'",
+    )
+    DEFAULT_PROVIDER: str = Field(
+        os.getenv("DEFAULT_PROVIDER", "groq"),
+        description="Провайдер по умолчанию без префикса: 'groq' или 'openai'",
     )
     DIALOG_HISTORY_LEN: int = int(os.getenv("DIALOG_HISTORY_LEN", 5))
 


### PR DESCRIPTION
## Summary
- prioritize double-dot prefix over single-dot and trim leading spaces
- use DEFAULT_PROVIDER when no prefix and enforce REQUIRE_PREFIX with hint
- guard against unknown providers and normalize DEFAULT_PROVIDER
- document REQUIRE_PREFIX and DEFAULT_PROVIDER in config, .env, and README
- clean up unused model variables and show HTML prefix legend in /start
- remove unused `mask` import in handler

## Testing
- `python -m py_compile src/handlers/gpt_handler.py src/config.py`
- `ruff check src/handlers/gpt_handler.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b38e2f1be4832ba3237497ca40f539