### PR TITLE
Silence on messages without prefix when required

### DIFF
--- a/src/handlers/gpt_handler.py
+++ b/src/handlers/gpt_handler.py
@@ -60,9 +60,7 @@ async def gpt_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
         provider, clean_text = _pick_provider(raw)
         if config.REQUIRE_PREFIX and provider is None:
-            await update.message.reply_html(
-                "Добавь префикс: <b>.</b> — дерзкий (Groq), <b>..</b> — вежливый (OpenAI)."
-            )
+            # В режиме REQUIRE_PREFIX=true бот полностью молчит на сообщения без префикса
             return
 
         if provider is None:


### PR DESCRIPTION
## Summary
- Make GPT handler ignore messages without prefix when REQUIRE_PREFIX is enabled

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b396a248b0832b9b747a7c4225ea21