### PR TITLE
Improve /add reliability and TMDb error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Антиспам отключён и не поддерживается.
-TELEGRAM_TOKEN=123:ABC
+BOT_TOKEN=123:ABC  # или TELEGRAM_TOKEN
 OPENAI_API_KEY=
 GROQ_API_KEY=
+DATABASE_URL=
+TMDB_KEY=
+LANG_FALLBACKS=ru,en
 
 # webhook
 WEBHOOK_URL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+- Startup verifies DB and TMDb key; logs "Bot started" with DB=ok TMDb=ok.
+- Unique constraint handling logs unknown names and retries short-id collisions.
+- `/add` validates year range with clearer hints and returns error IDs on failures.
+- TMDb errors (401/429/5xx) log status codes with response snippets.
+- Fallback English genres are marked with `(en)`; success logs include genres.
+- Export stub and logs now include movie title and year for easier checks.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Переменные окружения
 | Переменная | Назначение |
 | --- | --- |
-| `TELEGRAM_TOKEN` | токен бота |
+| `BOT_TOKEN` | токен бота |
 | `OPENAI_API_KEY` | ключ OpenAI |
 | `GROQ_API_KEY` | ключ Groq |
 | `WEBHOOK_URL` | URL вебхука (опц.) |
@@ -28,6 +28,9 @@
 | `DIALOG_HISTORY_LEN` | сколько пар реплик хранить в истории |
 | `LOG_CHAT_ID` | чат для логов (опц.) |
 | `LOG_FORMAT` | формат логов: `plain` или `json` |
+| `DATABASE_URL` | строка подключения к PostgreSQL |
+| `TMDB_KEY` | API ключ TMDb |
+| `LANG_FALLBACKS` | языки фоллбэка TMDb, через запятую |
 
 Антиспам отключён и не поддерживается.
 
@@ -51,3 +54,18 @@ TELEGRAM_TOKEN=123:ABC
 OPENAI_API_KEY=your-openai-key
 GROQ_API_KEY=your-groq-key
 ```
+
+## Проверка команды /add
+
+### Локально
+1. Создайте `.env` и задайте `BOT_TOKEN`, `DATABASE_URL`, `TMDB_KEY` (опц. `LANG_FALLBACKS=ru,en`).
+2. Установите зависимости: `pip install -r requirements.txt`.
+3. Запустите бота: `python main.py`.
+4. В Telegram отправьте: `/add Интерстеллар 2014`.
+5. При отсутствии обязательных переменных при запуске будет выведено имя переменной и подсказка, как её указать.
+
+### Railway
+1. В разделе **Settings → Variables** добавьте `BOT_TOKEN`, `DATABASE_URL`, `TMDB_KEY`.
+2. Задеплойте образ; в логах должно появиться `Bot started`.
+3. Проверьте команду `/add` в чате.
+4. Если какая-либо из переменных не задана, бот завершится с ошибкой и подскажет, какую переменную добавить.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ openai>=1.100.0,<2
 python-dotenv>=1.0.1
 pydantic>=2.8
 requests>=2.31
+asyncpg>=0.29
+httpx>=0.27

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,71 @@
+import logging
+import secrets
+from typing import Optional
+
+import asyncpg
+
+from .config import config
+
+
+class DuplicateTmdbError(Exception):
+    """Raised when tmdb_id is already present in DB."""
+
+
+pool: asyncpg.Pool | None = None
+TMDB_CONSTRAINTS = {"uniq_movies_tmdb_id", "movies_tmdb_id_key"}
+
+
+async def init() -> None:
+    global pool
+    try:
+        pool = await asyncpg.create_pool(dsn=config.DATABASE_URL)
+        logging.info("DB connected")
+    except Exception as e:  # connection/config errors
+        logging.error("db init failed: %s", e)
+        raise SystemExit("Не удалось подключиться к БД. Проверьте переменную окружения.")
+
+
+async def close() -> None:
+    if pool:
+        await pool.close()
+
+
+def _gen_id() -> str:
+    return secrets.token_hex(3)
+
+
+async def movie_exists_by_tmdb_id(tmdb_id: int) -> bool:
+    assert pool is not None
+    row = await pool.fetchrow("SELECT 1 FROM movies WHERE tmdb_id=$1", tmdb_id)
+    return row is not None
+
+
+async def insert_movie(*, title: str, year: int, genres: Optional[str], tmdb_id: int) -> str:
+    """Insert movie and return internal id."""
+    assert pool is not None
+    for _ in range(5):
+        movie_id = _gen_id()
+        try:
+            await pool.execute(
+                """
+                INSERT INTO movies (id, title, year, genres, status, tmdb_id, source)
+                VALUES ($1, $2, $3, $4, 'to_watch', $5, 'tmdb')
+                """,
+                movie_id,
+                title,
+                year,
+                genres,
+                tmdb_id,
+            )
+            return movie_id
+        except asyncpg.exceptions.UniqueViolationError as e:
+            cname = getattr(e, "constraint_name", "") or ""
+            logging.warning("unique violation constraint=%s", cname)
+            if cname in TMDB_CONSTRAINTS:
+                raise DuplicateTmdbError from e
+            if cname == "movies_pkey":
+                logging.warning("id collision: %s", movie_id)
+                continue
+            logging.error("unknown unique constraint=%s", cname)
+            raise
+    raise RuntimeError("Unable to generate unique id")

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,0 +1,18 @@
+"""Stub exporter. Real implementation will upload movies to cloud."""
+
+import logging
+
+
+async def export_movie(record: dict) -> None:
+    """Export movie record after successful addition.
+
+    Placeholder for future integration.
+    """
+    logging.info(
+        "export stub id=%s tmdb_id=%s title=%s year=%s",
+        record.get("id"),
+        record.get("tmdb_id"),
+        record.get("title"),
+        record.get("year"),
+    )
+

--- a/src/handlers/add.py
+++ b/src/handlers/add.py
@@ -1,0 +1,152 @@
+import logging
+import uuid
+from typing import Optional
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src import db
+from src.config import config
+from src.db import DuplicateTmdbError
+from src.tmdb_client import (
+    TMDbAuthError,
+    TMDbRateLimitError,
+    TMDbUnavailableError,
+    TMDbError,
+    tmdb_client,
+)
+from src.exporter import export_movie
+
+FORMAT_ERROR = "Формат: /add Название 2014"
+YEAR_ERROR = "Формат: /add Название 2014 (год должен быть от 1888 до 2100)"
+NOT_FOUND = "Не нашёл такой фильм в базе TMDb. Попробуй другое написание."
+NO_DATE = "В TMDb нет корректной даты релиза по этому фильму, добавление отменено."
+DUPLICATE = "Этот фильм уже в списке (найдён по TMDb)."
+AUTH_ERROR = "Проблема авторизации TMDb. Проверьте TMDB_KEY."
+RATE_ERROR = "TMDb ограничил частоту запросов. Попробуйте чуть позже."
+TMDB_UNAVAILABLE = "Сервис TMDb временно недоступен, попробуйте позже."
+TECH_ERROR_TEMPLATE = "⚠️ Сервис временно недоступен (id={})"
+
+
+class YearFormatError(Exception):
+    pass
+
+
+def _parse(args: list[str]) -> tuple[str, int]:
+    if len(args) < 2:
+        raise ValueError
+    year_str = args[-1].strip()
+    if not year_str.isdigit() or len(year_str) != 4:
+        raise YearFormatError
+    year = int(year_str)
+    if year < 1888 or year > 2100:
+        raise YearFormatError
+    title = " ".join(a.strip() for a in args[:-1]).strip()
+    if len(title) < 2:
+        raise ValueError
+    return title, year
+
+
+async def add_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message:
+        return
+    try:
+        raw = update.message.text or ""
+        logging.info("/add raw=%r", raw)
+        try:
+            query_title, user_year = _parse(context.args)
+        except YearFormatError:
+            logging.warning("/add year_format_error")
+            await update.message.reply_text(YEAR_ERROR)
+            return
+        except ValueError:
+            logging.warning("/add format_error")
+            await update.message.reply_text(FORMAT_ERROR)
+            return
+        logging.info("/add normalized title=%s year=%s", query_title, user_year)
+
+        try:
+            movie_id = await tmdb_client.search_movie(query_title, user_year)
+            if not movie_id:
+                logging.warning("/add not_found title=%s year=%s", query_title, user_year)
+                await update.message.reply_text(NOT_FOUND)
+                return
+            details = await tmdb_client.get_movie_details(movie_id)
+            if not details:
+                logging.warning("/add tmdb_id=%s no_date", movie_id)
+                await update.message.reply_text(NO_DATE)
+                return
+        except TMDbAuthError:
+            logging.error("/add tmdb_auth_error")
+            await update.message.reply_text(AUTH_ERROR)
+            return
+        except TMDbRateLimitError:
+            logging.warning("/add tmdb_rate_limit")
+            await update.message.reply_text(RATE_ERROR)
+            return
+        except TMDbUnavailableError:
+            logging.error("/add tmdb_unavailable")
+            await update.message.reply_text(TMDB_UNAVAILABLE)
+            return
+        except TMDbError:
+            rid = uuid.uuid4().hex[:8].upper()
+            logging.error("/add tmdb_error id=%s", rid)
+            await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+            return
+        except Exception:
+            rid = uuid.uuid4().hex[:8].upper()
+            logging.exception("/add unexpected_tmdb_error id=%s", rid)
+            await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+            return
+
+        try:
+            if await db.movie_exists_by_tmdb_id(details.tmdb_id):
+                logging.warning("/add tmdb_id=%s duplicate_precheck", details.tmdb_id)
+                await update.message.reply_text(DUPLICATE)
+                return
+            new_id = await db.insert_movie(
+                title=details.title,
+                year=details.year,
+                genres=details.genres,
+                tmdb_id=details.tmdb_id,
+            )
+        except DuplicateTmdbError:
+            logging.warning("/add tmdb_id=%s duplicate_race", details.tmdb_id)
+            await update.message.reply_text(DUPLICATE)
+            return
+        except Exception:
+            rid = uuid.uuid4().hex[:8].upper()
+            logging.exception("/add db_error id=%s", rid)
+            await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+            return
+
+        genres_text = details.genres if details.genres else "жанры не указаны"
+        if details.genres and details.genres_lang and details.genres_lang != config.LANG_FALLBACKS[0]:
+            genres_text = f"{genres_text} ({details.genres_lang})"
+        await update.message.reply_text(
+            f"➕ Добавлено #{new_id}\n🎥 «{details.title}» ({details.year}) — {genres_text}"
+        )
+        logging.info(
+            "/add success title=%s tmdb_id=%s year=%s id=%s genres=%s",
+            query_title,
+            details.tmdb_id,
+            details.year,
+            new_id,
+            details.genres,
+        )
+        try:
+            await export_movie(
+                {
+                    "id": new_id,
+                    "tmdb_id": details.tmdb_id,
+                    "title": details.title,
+                    "year": details.year,
+                }
+            )
+        except Exception:
+            logging.exception("export_movie failed")
+    except Exception:
+        rid = uuid.uuid4().hex[:8].upper()
+        logging.exception("/add unexpected_error id=%s", rid)
+        await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+

--- a/src/tmdb_client.py
+++ b/src/tmdb_client.py
@@ -1,0 +1,146 @@
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from .config import config
+
+
+class TMDbError(Exception):
+    pass
+
+
+class TMDbAuthError(TMDbError):
+    pass
+
+
+class TMDbRateLimitError(TMDbError):
+    pass
+
+
+class TMDbUnavailableError(TMDbError):
+    pass
+
+
+@dataclass
+class MovieDetails:
+    tmdb_id: int
+    title: str
+    year: int
+    genres: Optional[str]
+    genres_lang: Optional[str] = None
+
+
+class TMDbClient:
+    def __init__(self, api_key: str, languages: list[str]):
+        self.api_key = api_key
+        self.languages = languages or ["ru", "en"]
+        self._client = httpx.AsyncClient(
+            base_url="https://api.themoviedb.org/3", timeout=10
+        )
+        self._search_cache: dict[tuple[str, Optional[int]], tuple[float, Optional[int]]] = {}
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def _get(self, path: str, params: dict, retries: int = 2) -> dict:
+        params = {**params, "api_key": self.api_key}
+        delay = 1
+        for attempt in range(retries):
+            try:
+                r = await self._client.get(path, params=params)
+            except httpx.RequestError as e:
+                logging.error("tmdb network error: %s", e)
+                if attempt == retries - 1:
+                    raise TMDbUnavailableError from e
+                await asyncio.sleep(delay)
+                delay *= 2
+                continue
+            text = r.text[:100].replace("\n", " ")
+            logging.debug("tmdb %s %s", r.status_code, text)
+            if r.status_code == 401:
+                logging.error("tmdb 401: %s", text)
+                raise TMDbAuthError
+            if r.status_code == 429:
+                logging.warning("tmdb 429: %s", text)
+                raise TMDbRateLimitError
+            if r.status_code >= 500:
+                logging.error("tmdb %s: %s", r.status_code, text)
+                if attempt == retries - 1:
+                    raise TMDbUnavailableError
+                await asyncio.sleep(delay)
+                delay *= 2
+                continue
+            r.raise_for_status()
+            return r.json()
+        raise TMDbUnavailableError
+
+    async def search_movie(self, query: str, year: Optional[int]) -> Optional[int]:
+        key = (query.lower(), year)
+        cached = self._search_cache.get(key)
+        now = time.time()
+        if cached and now - cached[0] < 60:
+            return cached[1]
+
+        result_id: Optional[int] = None
+        for lang in self.languages:
+            params = {"query": query, "language": lang}
+            if year:
+                params["year"] = year
+                data = await self._get("/search/movie", params)
+                results = data.get("results") or []
+                if results:
+                    break
+                params.pop("year")
+            data = await self._get("/search/movie", params)
+            results = data.get("results") or []
+            if results:
+                break
+        if results:
+            results.sort(
+                key=lambda r: (r.get("popularity", 0), r.get("vote_count", 0)),
+                reverse=True,
+            )
+            result_id = results[0]["id"]
+        self._search_cache[key] = (now, result_id)
+        return result_id
+
+    async def get_movie_details(self, movie_id: int) -> Optional[MovieDetails]:
+        first_details: MovieDetails | None = None
+        for lang in self.languages:
+            data = await self._get(f"/movie/{movie_id}", {"language": lang})
+            if not data:
+                continue
+            title = data.get("title") or data.get("original_title")
+            release_date = data.get("release_date") or ""
+            if len(release_date) < 4:
+                return None
+            try:
+                year = int(release_date[:4])
+            except ValueError:
+                return None
+            genres = ", ".join(g.get("name") for g in data.get("genres") or []) or None
+            if not first_details:
+                first_details = MovieDetails(
+                    tmdb_id=data["id"],
+                    title=title,
+                    year=year,
+                    genres=genres,
+                    genres_lang=lang if genres else None,
+                )
+                if genres:
+                    return first_details
+            if genres and not first_details.genres:
+                first_details.genres = genres
+                first_details.genres_lang = lang
+                return first_details
+        return first_details
+
+    async def check_key(self) -> None:
+        await self._get("/configuration", {})
+
+
+tmdb_client = TMDbClient(config.TMDB_KEY, config.LANG_FALLBACKS)


### PR DESCRIPTION
## Summary
- log startup health after checking DB and TMDb key
- return detailed IDs for unexpected `/add` failures and annotate English genre fallbacks
- surface TMDb responses on errors and log unknown DB constraint names

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6ba3ba4832baef135f410b5e95a