### PR TITLE
Graceful shutdown via PTB lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Graceful shutdown via PTB lifecycle hooks; resources close cleanly.
+- Removed direct asyncio.run calls to avoid event loop errors.
+- Startup and shutdown logs report DB and TMDb client status.
 - Startup verifies DB and TMDb key; logs "Bot started" with DB=ok TMDb=ok.
 - Unique constraint handling logs unknown names and retries short-id collisions.
 - `/add` validates year range with clearer hints and returns error IDs on failures.


### PR DESCRIPTION
## Summary
- initialize DB pool and TMDb client in PTB `post_init` hook
- close resources in `post_stop` hook and log shutdown statuses
- drop `asyncio.run` usage in `main`

## Testing
- `python -m py_compile main.py src/db.py src/tmdb_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9ab7fff00832ba11a0028018f03a8