### PR TITLE
Add TMDb confirmation dialog and candidate scoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,12 @@ import json
 import logging
 import uuid
 
-from telegram.ext import Application, CommandHandler, MessageHandler, filters
+from telegram.ext import Application, CommandHandler, MessageHandler, filters, CallbackQueryHandler
 
 from src.config import config
 from src.handlers.gpt_handler import gpt_handler, id_handler, start_handler
 from src.handlers.add import add_handler
+from src.handlers.add_callback import add_callback_handler
 from src import db
 from src.tmdb_client import TMDbAuthError, TMDbError, tmdb_client
 from src.utils.text_utils import mask
@@ -104,6 +105,7 @@ def main() -> None:
     app.add_handler(CommandHandler("start", start_handler))
     app.add_handler(CommandHandler("id", id_handler))
     app.add_handler(CommandHandler("add", add_handler))
+    app.add_handler(CallbackQueryHandler(add_callback_handler, pattern=r"^ADD_"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, gpt_handler))
 
     app.add_error_handler(on_error)

--- a/src/config.py
+++ b/src/config.py
@@ -80,6 +80,8 @@ class Settings(BaseModel):
         ]
     )
 
+    ADD_CONFIRMATION_MODE: str = os.getenv("ADD_CONFIRMATION_MODE", "strict")
+
 
 try:
     # Мини-валидация диапазонов + понятная диагностика

--- a/src/db.py
+++ b/src/db.py
@@ -40,6 +40,18 @@ async def movie_exists_by_tmdb_id(tmdb_id: int) -> bool:
     return row is not None
 
 
+async def get_movie_by_tmdb_id(tmdb_id: int) -> Optional[tuple[str, str, int]]:
+    """Return (id, title, year) if movie exists."""
+    assert pool is not None
+    row = await pool.fetchrow(
+        "SELECT id, title, year FROM movies WHERE tmdb_id=$1",
+        tmdb_id,
+    )
+    if row:
+        return row["id"], row["title"], row["year"]
+    return None
+
+
 async def insert_movie(*, title: str, year: int, genres: Optional[str], tmdb_id: int) -> str:
     """Insert movie and return internal id."""
     assert pool is not None

--- a/src/handlers/add.py
+++ b/src/handlers/add.py
@@ -1,8 +1,10 @@
 import logging
+import time
 import uuid
+import re
 from typing import Optional
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from src import db
@@ -10,29 +12,85 @@ from src.config import config
 from src.db import DuplicateTmdbError
 from src.tmdb_client import (
     TMDbAuthError,
+    TMDbError,
     TMDbRateLimitError,
     TMDbUnavailableError,
-    TMDbError,
     tmdb_client,
+    Candidate,
 )
 from src.exporter import export_movie
+from src.i18n import t
 
 FORMAT_ERROR = "Формат: /add Название 2014"
 YEAR_ERROR = "Формат: /add Название 2014 (год должен быть от 1888 до 2100)"
 NOT_FOUND = "Не нашёл такой фильм в базе TMDb. Попробуй другое написание."
 NO_DATE = "В TMDb нет корректной даты релиза по этому фильму, добавление отменено."
-DUPLICATE = "Этот фильм уже в списке (найдён по TMDb)."
 AUTH_ERROR = "Проблема авторизации TMDb. Проверьте TMDB_KEY."
 RATE_ERROR = "TMDb ограничил частоту запросов. Попробуйте чуть позже."
 TMDB_UNAVAILABLE = "Сервис TMDb временно недоступен, попробуйте позже."
 TECH_ERROR_TEMPLATE = "⚠️ Сервис временно недоступен (id={})"
+DUPLICATE_SIMPLE = "Этот фильм уже в списке (найдён по TMDb)."
+
+PENDING_TTL = 120
+_pending: dict[tuple[int, int, int], dict] = {}
+
+PART_KEYWORDS = {
+    "part",
+    "chapter",
+    "volume",
+    "season",
+    "сезон",
+    "фильм",
+    "film",
+}
+
+ROMAN_MAP = {
+    "I": 1,
+    "II": 2,
+    "III": 3,
+    "IV": 4,
+    "V": 5,
+    "VI": 6,
+    "VII": 7,
+    "VIII": 8,
+    "IX": 9,
+    "X": 10,
+}
+
+EMOJI_NUM = {
+    1: "1️⃣",
+    2: "2️⃣",
+    3: "3️⃣",
+    4: "4️⃣",
+    5: "5️⃣",
+    6: "6️⃣",
+    7: "7️⃣",
+    8: "8️⃣",
+    9: "9️⃣",
+    10: "🔟",
+}
+
+
+def _extract_part_from_title(title: str) -> Optional[int]:
+    pattern = r"(?i)(?:part|chapter|volume|season|сезон|фильм|film)\s*(\d+|i{1,3}|iv|v|vi{0,3}|ix|x)\b"
+    m = re.search(pattern, title)
+    if not m:
+        return None
+    token = m.group(1)
+    if token.isdigit():
+        return int(token)
+    return ROMAN_MAP.get(token.upper())
+
+
+def _part_emoji(num: Optional[int]) -> str:
+    return EMOJI_NUM.get(num or 0, "")
 
 
 class YearFormatError(Exception):
     pass
 
 
-def _parse(args: list[str]) -> tuple[str, int]:
+def _parse(args: list[str]) -> tuple[str, int, Optional[int]]:
     if len(args) < 2:
         raise ValueError
     year_str = args[-1].strip()
@@ -41,10 +99,43 @@ def _parse(args: list[str]) -> tuple[str, int]:
     year = int(year_str)
     if year < 1888 or year > 2100:
         raise YearFormatError
-    title = " ".join(a.strip() for a in args[:-1]).strip()
+    title_parts = [a.strip() for a in args[:-1] if a.strip()]
+    if not title_parts:
+        raise ValueError
+    part_hint: Optional[int] = None
+    if len(title_parts) >= 2:
+        prev = title_parts[-2].lower()
+        token = title_parts[-1]
+        if prev in PART_KEYWORDS:
+            if token.isdigit():
+                part_hint = int(token)
+                title_parts = title_parts[:-2]
+            elif token.upper() in ROMAN_MAP:
+                part_hint = ROMAN_MAP[token.upper()]
+                title_parts = title_parts[:-2]
+    title = " ".join(title_parts).strip()
     if len(title) < 2:
         raise ValueError
-    return title, year
+    return title, year, part_hint
+
+
+def _cleanup_expired() -> None:
+    now = time.time()
+    for key, value in list(_pending.items()):
+        if value["expires_at"] <= now:
+            _pending.pop(key, None)
+
+
+async def _timeout_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    data = context.job.data
+    key = data["key"]
+    pending = _pending.pop(key, None)
+    if pending:
+        logging.warning("/add timeout")
+        await context.bot.send_message(
+            data["chat_id"],
+            t("timeout", lang=pending["lang"], query=pending["query"]),
+        )
 
 
 async def add_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -53,8 +144,9 @@ async def add_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     try:
         raw = update.message.text or ""
         logging.info("/add raw=%r", raw)
+        lang = update.effective_user.language_code or config.LANG_FALLBACKS[0]
         try:
-            query_title, user_year = _parse(context.args)
+            query_title, user_year, part_hint = _parse(context.args)
         except YearFormatError:
             logging.warning("/add year_format_error")
             await update.message.reply_text(YEAR_ERROR)
@@ -63,19 +155,37 @@ async def add_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             logging.warning("/add format_error")
             await update.message.reply_text(FORMAT_ERROR)
             return
-        logging.info("/add normalized title=%s year=%s", query_title, user_year)
+        logging.info(
+            "/add normalized title=%s year=%s part=%s", query_title, user_year, part_hint
+        )
+
+        _cleanup_expired()
+        chat_id = update.effective_chat.id
+        user_id = update.effective_user.id
+        for key in list(_pending.keys()):
+            if key[0] == chat_id and key[1] == user_id:
+                _pending.pop(key, None)
+                await update.message.reply_text(t("old_cancelled", lang=lang))
 
         try:
-            movie_id = await tmdb_client.search_movie(query_title, user_year)
-            if not movie_id:
-                logging.warning("/add not_found title=%s year=%s", query_title, user_year)
+            candidates = await tmdb_client.search_candidates(query_title, user_year)
+            if not candidates:
+                logging.warning(
+                    "/add not_found title=%s year=%s", query_title, user_year
+                )
                 await update.message.reply_text(NOT_FOUND)
                 return
-            details = await tmdb_client.get_movie_details(movie_id)
-            if not details:
-                logging.warning("/add tmdb_id=%s no_date", movie_id)
-                await update.message.reply_text(NO_DATE)
-                return
+            if candidates[0].belongs_to_collection_id:
+                try:
+                    coll = await tmdb_client.fetch_collection_parts(
+                        candidates[0].belongs_to_collection_id
+                    )
+                    candidates.extend(coll)
+                except TMDbError:
+                    pass
+            candidates = tmdb_client.score_candidates(
+                candidates, user_year, part_hint, query_title
+            )
         except TMDbAuthError:
             logging.error("/add tmdb_auth_error")
             await update.message.reply_text(AUTH_ERROR)
@@ -99,54 +209,154 @@ async def add_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
             return
 
-        try:
-            if await db.movie_exists_by_tmdb_id(details.tmdb_id):
-                logging.warning("/add tmdb_id=%s duplicate_precheck", details.tmdb_id)
-                await update.message.reply_text(DUPLICATE)
+        # dedupe
+        unique: dict[int, Candidate] = {}
+        for c in candidates:
+            prev = unique.get(c.tmdb_id)
+            if not prev or prev.score < c.score:
+                unique[c.tmdb_id] = c
+        candidates = sorted(unique.values(), key=lambda c: c.score, reverse=True)
+        candidates = [c for c in candidates if c.media_type == "movie"]
+
+        top1 = candidates[0]
+        top2 = candidates[1] if len(candidates) > 1 else None
+        top3 = candidates[2] if len(candidates) > 2 else None
+        year_mismatch = top1.release_year is not None and top1.release_year != user_year
+        if config.ADD_CONFIRMATION_MODE.lower() != "relaxed":
+            confirm_year = year_mismatch
+        else:
+            confirm_year = False
+        gap_close = False
+        if top2 and top1.score < top2.score * 1.2:
+            gap_close = True
+        if top3 and top1.score < top3.score * 1.2:
+            gap_close = True
+        collection_trigger = top1.belongs_to_collection_id is not None and part_hint is None
+        unknown_year = top1.release_year is None
+        confirm = confirm_year or gap_close or collection_trigger or unknown_year
+
+        if not confirm:
+            try:
+                details = await tmdb_client.get_movie_details(top1.tmdb_id)
+                if not details:
+                    await update.message.reply_text(NO_DATE)
+                    return
+            except TMDbError:
+                rid = uuid.uuid4().hex[:8].upper()
+                logging.error("/add tmdb_error id=%s", rid)
+                await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
                 return
-            new_id = await db.insert_movie(
-                title=details.title,
-                year=details.year,
-                genres=details.genres,
-                tmdb_id=details.tmdb_id,
+            except Exception:
+                rid = uuid.uuid4().hex[:8].upper()
+                logging.exception("/add unexpected_tmdb_error id=%s", rid)
+                await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+                return
+
+            try:
+                if await db.movie_exists_by_tmdb_id(details.tmdb_id):
+                    logging.warning("/add tmdb_id=%s duplicate_precheck", details.tmdb_id)
+                    await update.message.reply_text(DUPLICATE_SIMPLE)
+                    return
+                new_id = await db.insert_movie(
+                    title=details.title,
+                    year=details.year,
+                    genres=details.genres,
+                    tmdb_id=details.tmdb_id,
+                )
+            except DuplicateTmdbError:
+                logging.warning("/add tmdb_id=%s duplicate_race", details.tmdb_id)
+                await update.message.reply_text(DUPLICATE_SIMPLE)
+                return
+            except Exception:
+                rid = uuid.uuid4().hex[:8].upper()
+                logging.exception("/add db_error id=%s", rid)
+                await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+                return
+
+            genres_text = details.genres if details.genres else "жанры не указаны"
+            if (
+                details.genres
+                and details.genres_lang
+                and details.genres_lang != config.LANG_FALLBACKS[0]
+            ):
+                genres_text = f"{genres_text} ({details.genres_lang})"
+            await update.message.reply_text(
+                f"➕ Добавлено #{new_id}\n🎥 «{details.title}» ({details.year}) — {genres_text}"
             )
-        except DuplicateTmdbError:
-            logging.warning("/add tmdb_id=%s duplicate_race", details.tmdb_id)
-            await update.message.reply_text(DUPLICATE)
-            return
-        except Exception:
-            rid = uuid.uuid4().hex[:8].upper()
-            logging.exception("/add db_error id=%s", rid)
-            await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+            logging.info(
+                "/add auto tmdb_id=%s year=%s id=%s", details.tmdb_id, details.year, new_id
+            )
+            try:
+                await export_movie(
+                    {
+                        "id": new_id,
+                        "tmdb_id": details.tmdb_id,
+                        "title": details.title,
+                        "year": details.year,
+                    }
+                )
+            except Exception:
+                logging.exception("export_movie failed")
             return
 
-        genres_text = details.genres if details.genres else "жанры не указаны"
-        if details.genres and details.genres_lang and details.genres_lang != config.LANG_FALLBACKS[0]:
-            genres_text = f"{genres_text} ({details.genres_lang})"
-        await update.message.reply_text(
-            f"➕ Добавлено #{new_id}\n🎥 «{details.title}» ({details.year}) — {genres_text}"
+        # confirmation dialog
+        reasons = []
+        if confirm_year:
+            reasons.append("ambiguous_year")
+        if gap_close:
+            reasons.append("close_scores")
+        if collection_trigger:
+            reasons.append("collection")
+        if unknown_year:
+            reasons.append("unknown_year")
+        logging.warning(
+            "/add ambiguous -> dialog reason=%s top1_id=%s top1_score=%.2f top2_score=%.2f top3_score=%.2f",
+            "|".join(reasons),
+            top1.tmdb_id,
+            top1.score,
+            top2.score if top2 else 0,
+            top3.score if top3 else 0,
         )
-        logging.info(
-            "/add success title=%s tmdb_id=%s year=%s id=%s genres=%s",
-            query_title,
-            details.tmdb_id,
-            details.year,
-            new_id,
-            details.genres,
-        )
-        try:
-            await export_movie(
-                {
-                    "id": new_id,
-                    "tmdb_id": details.tmdb_id,
-                    "title": details.title,
-                    "year": details.year,
-                }
+        options = candidates[:5]
+        keyboard_buttons = []
+        for c in options:
+            part_num = _extract_part_from_title(c.title_localized) or _extract_part_from_title(c.original_title)
+            year_text = c.release_year if c.release_year is not None else t("year_unknown", lang=lang)
+            prefix = f"{_part_emoji(part_num)} " if part_num else ""
+            btn = InlineKeyboardButton(
+                f"{prefix}{c.title_localized} ({year_text})",
+                callback_data=f"ADD_PICK:{c.tmdb_id}",
             )
-        except Exception:
-            logging.exception("export_movie failed")
+            keyboard_buttons.append([btn])
+        keyboard_buttons.append(
+            [
+                InlineKeyboardButton(t("add_found_btn", lang=lang), callback_data="ADD_TOP1"),
+                InlineKeyboardButton(t("cancel_btn", lang=lang), callback_data="ADD_CANCEL"),
+            ]
+        )
+        keyboard = InlineKeyboardMarkup(keyboard_buttons)
+        if collection_trigger:
+            text = t("series_prompt", lang=lang, base_title=top1.title_localized)
+        elif confirm_year:
+            text = t("year_prompt", lang=lang, user_year=user_year)
+        else:
+            text = t("year_prompt", lang=lang, user_year=user_year)
+        msg = await update.message.reply_text(text, reply_markup=keyboard)
+        key = (chat_id, user_id, msg.message_id)
+        _pending[key] = {
+            "query": query_title,
+            "user_year": user_year,
+            "options": {c.tmdb_id: c for c in options},
+            "top1_tmdb_id": top1.tmdb_id,
+            "expires_at": time.time() + PENDING_TTL,
+            "lang": lang,
+        }
+        context.job_queue.run_once(
+            _timeout_job,
+            PENDING_TTL,
+            data={"key": key, "chat_id": chat_id, "lang": lang},
+        )
     except Exception:
         rid = uuid.uuid4().hex[:8].upper()
         logging.exception("/add unexpected_error id=%s", rid)
         await update.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
-

--- a/src/handlers/add_callback.py
+++ b/src/handlers/add_callback.py
@@ -1,0 +1,137 @@
+import logging
+import time
+import uuid
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src import db
+from src.db import DuplicateTmdbError, get_movie_by_tmdb_id
+from src.tmdb_client import tmdb_client, TMDbError
+from src.config import config
+from src.i18n import t
+from src.exporter import export_movie
+from .add import _pending, NO_DATE, TECH_ERROR_TEMPLATE
+
+
+async def add_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if not query or not query.message:
+        return
+    data = query.data or ""
+    chat_id = query.message.chat_id
+    user_id = query.from_user.id
+    lang = update.effective_user.language_code or config.LANG_FALLBACKS[0]
+    key = (chat_id, user_id, query.message.message_id)
+    pending = _pending.get(key)
+    if not pending:
+        await query.answer()
+        return
+    lang = pending.get("lang", lang)
+    if pending["expires_at"] <= time.time():
+        _pending.pop(key, None)
+        await query.message.reply_text(t("timeout", lang=lang, query=pending["query"]))
+        await query.answer()
+        return
+
+    if data == "ADD_CANCEL":
+        _pending.pop(key, None)
+        logging.warning("/add cancelled")
+        await query.message.reply_text(t("cancelled", lang=lang))
+        await query.answer()
+        return
+
+    if data == "ADD_TOP1":
+        tmdb_id = pending["top1_tmdb_id"]
+    elif data.startswith("ADD_PICK:"):
+        try:
+            tmdb_id = int(data.split(":", 1)[1])
+        except ValueError:
+            await query.answer()
+            return
+        if tmdb_id not in pending["options"]:
+            await query.answer()
+            return
+    else:
+        await query.answer()
+        return
+
+    try:
+        details = await tmdb_client.get_movie_details(tmdb_id)
+        if not details:
+            await query.message.reply_text(NO_DATE)
+            _pending.pop(key, None)
+            await query.answer()
+            return
+    except TMDbError:
+        rid = uuid.uuid4().hex[:8].upper()
+        logging.error("/add callback tmdb_error id=%s", rid)
+        await query.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+        _pending.pop(key, None)
+        await query.answer()
+        return
+    except Exception:
+        rid = uuid.uuid4().hex[:8].upper()
+        logging.exception("/add callback unexpected_tmdb_error id=%s", rid)
+        await query.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+        _pending.pop(key, None)
+        await query.answer()
+        return
+
+    existing = await get_movie_by_tmdb_id(tmdb_id)
+    if existing:
+        short_id, title, year = existing
+        await query.message.reply_text(t("duplicate", lang=lang, short_id=short_id, title=title, year=year))
+        _pending.pop(key, None)
+        await query.answer()
+        return
+
+    try:
+        new_id = await db.insert_movie(
+            title=details.title,
+            year=details.year,
+            genres=details.genres,
+            tmdb_id=details.tmdb_id,
+        )
+    except DuplicateTmdbError:
+        existing = await get_movie_by_tmdb_id(tmdb_id)
+        if existing:
+            short_id, title, year = existing
+            await query.message.reply_text(
+                t("duplicate", lang=lang, short_id=short_id, title=title, year=year)
+            )
+        else:
+            await query.message.reply_text(
+                t("duplicate", lang=lang, short_id="", title=details.title, year=details.year)
+            )
+        _pending.pop(key, None)
+        await query.answer()
+        return
+    except Exception:
+        rid = uuid.uuid4().hex[:8].upper()
+        logging.exception("/add callback db_error id=%s", rid)
+        await query.message.reply_text(TECH_ERROR_TEMPLATE.format(rid))
+        _pending.pop(key, None)
+        await query.answer()
+        return
+
+    genres_text = details.genres if details.genres else "жанры не указаны"
+    if details.genres and details.genres_lang and details.genres_lang != config.LANG_FALLBACKS[0]:
+        genres_text = f"{genres_text} ({details.genres_lang})"
+    await query.message.reply_text(
+        t("added", lang=lang, title=details.title, year=details.year, genres=genres_text)
+    )
+    logging.info("/add confirm tmdb_id=%s year=%s id=%s", details.tmdb_id, details.year, new_id)
+    _pending.pop(key, None)
+    try:
+        await export_movie(
+            {
+                "id": new_id,
+                "tmdb_id": details.tmdb_id,
+                "title": details.title,
+                "year": details.year,
+            }
+        )
+    except Exception:
+        logging.exception("export_movie failed")
+    await query.answer()

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from .config import config
+
+MESSAGES = {
+    "ru": {
+        "series_prompt": "Похоже, это серия “{base_title}”. Уточните часть:",
+        "year_prompt": "Не нашёл точное совпадение по году {user_year}. Возможные варианты:",
+        "added": "Ок, добавляю: “{title}” ({year}). Жанры: {genres}.",
+        "duplicate": "Этот фильм уже в списке: #{short_id} — “{title}” ({year}).",
+        "cancelled": "Отменено.",
+        "timeout": "Время выбора истекло — попробуйте снова: /add {query}.",
+        "old_cancelled": "Старая попытка отменена.",
+        "add_found_btn": "Добавить найденный",
+        "cancel_btn": "Отмена",
+        "year_unknown": "год неизвестен",
+    },
+    "en": {
+        "series_prompt": "Looks like it's a series '{base_title}'. Choose a part:",
+        "year_prompt": "No exact match for year {user_year}. Possible options:",
+        "added": "Ok, adding: '{title}' ({year}). Genres: {genres}.",
+        "duplicate": "This movie is already in the list: #{short_id} — '{title}' ({year}).",
+        "cancelled": "Cancelled.",
+        "timeout": "Timeout — try again: /add {query}.",
+        "old_cancelled": "Previous attempt cancelled.",
+        "add_found_btn": "Add found",
+        "cancel_btn": "Cancel",
+        "year_unknown": "year unknown",
+    },
+}
+
+
+def t(key: str, lang: str | None = None, **kwargs) -> str:
+    lang = lang or config.LANG_FALLBACKS[0]
+    table = MESSAGES.get(lang) or MESSAGES["en"]
+    text = table.get(key) or MESSAGES["en"].get(key, "")
+    return text.format(**kwargs)

--- a/src/tmdb_client.py
+++ b/src/tmdb_client.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 import httpx
 
@@ -32,6 +32,19 @@ class MovieDetails:
     year: int
     genres: Optional[str]
     genres_lang: Optional[str] = None
+
+
+@dataclass
+class Candidate:
+    tmdb_id: int
+    title_localized: str
+    original_title: str
+    release_year: int | None
+    popularity: float
+    media_type: str
+    belongs_to_collection_id: int | None = None
+    score: float = 0.0
+    lang: str | None = None
 
 
 class TMDbClient:
@@ -77,6 +90,139 @@ class TMDbClient:
             r.raise_for_status()
             return r.json()
         raise TMDbUnavailableError
+
+    async def search_candidates(self, query: str, user_year: int | None) -> List[Candidate]:
+        """Return list of movie candidates for given query."""
+        results: list[dict] = []
+        for lang in self.languages:
+            params = {"query": query, "language": lang}
+            if user_year:
+                params["year"] = user_year
+                data = await self._get("/search/movie", params)
+                results = data.get("results") or []
+                if results:
+                    break
+                params.pop("year")
+            data = await self._get("/search/movie", params)
+            results = data.get("results") or []
+            if results:
+                break
+
+        candidates: list[Candidate] = []
+        for r in results[:10]:
+            media_type = "movie"  # search/movie returns movies only
+            if media_type != "movie":
+                continue
+            release_date = r.get("release_date") or ""
+            release_year = None
+            if len(release_date) >= 4:
+                try:
+                    release_year = int(release_date[:4])
+                except ValueError:
+                    release_year = None
+            cand = Candidate(
+                tmdb_id=r.get("id"),
+                title_localized=r.get("title") or r.get("original_title") or "",
+                original_title=r.get("original_title") or r.get("title") or "",
+                release_year=release_year,
+                popularity=r.get("popularity", 0.0),
+                media_type=media_type,
+                lang=lang,
+            )
+            candidates.append(cand)
+
+        # enrich with collection ids for top results
+        for cand in candidates[:5]:
+            try:
+                data = await self._get(f"/movie/{cand.tmdb_id}", {"language": self.languages[0]})
+            except TMDbError:
+                data = {}
+            belongs = data.get("belongs_to_collection") or {}
+            cand.belongs_to_collection_id = belongs.get("id")
+
+        return candidates
+
+    async def fetch_collection_parts(self, collection_id: int) -> List[Candidate]:
+        data = await self._get(
+            f"/collection/{collection_id}", {"language": self.languages[0]}
+        )
+        parts = data.get("parts") or []
+        candidates: list[Candidate] = []
+        for p in parts:
+            release_date = p.get("release_date") or ""
+            release_year = None
+            if len(release_date) >= 4:
+                try:
+                    release_year = int(release_date[:4])
+                except ValueError:
+                    release_year = None
+            candidates.append(
+                Candidate(
+                    tmdb_id=p.get("id"),
+                    title_localized=p.get("title") or p.get("name") or "",
+                    original_title=p.get("original_title") or p.get("title") or "",
+                    release_year=release_year,
+                    popularity=p.get("popularity", 0.0),
+                    media_type="movie",
+                    belongs_to_collection_id=collection_id,
+                )
+            )
+        return candidates
+
+    def score_candidates(
+        self,
+        cands: List[Candidate],
+        user_year: int | None,
+        part_hint: int | None,
+        query: str | None,
+    ) -> List[Candidate]:
+        """Apply heuristic scoring and return sorted list."""
+
+        def _has_part(title: str, part: int) -> bool:
+            title_lower = title.lower()
+            arabic = str(part)
+            romans = [
+                "i",
+                "ii",
+                "iii",
+                "iv",
+                "v",
+                "vi",
+                "vii",
+                "viii",
+                "ix",
+                "x",
+            ]
+            roman = romans[part - 1] if 0 < part <= len(romans) else ""
+            patterns = [
+                arabic,
+                roman,
+                f"part {arabic}",
+                f"part {roman}",
+                f"chapter {arabic}",
+                f"chapter {roman}",
+                f"volume {arabic}",
+                f"volume {roman}",
+            ]
+            return any(p in title_lower for p in patterns if p)
+
+        for cand in cands:
+            score = cand.popularity
+            if user_year and cand.release_year == user_year:
+                score *= 1.1
+            if part_hint and (
+                _has_part(cand.title_localized, part_hint)
+                or _has_part(cand.original_title, part_hint)
+            ):
+                score *= 1.2
+            if query and (
+                cand.title_localized.lower() == query.lower()
+                or cand.original_title.lower() == query.lower()
+            ):
+                score *= 1.1
+            cand.score = score
+        cands.sort(key=lambda c: c.score, reverse=True)
+        return cands
 
     async def search_movie(self, query: str, year: Optional[int]) -> Optional[int]:
         key = (query.lower(), year)


### PR DESCRIPTION
## Summary
- refine part-number heuristics and highlight recognized sequels in confirmation dialogs
- consider top-3 score gaps and log detailed reasons when fallback to confirmation
- localize add dialog buttons/messages and score exact title matches for better accuracy

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b9c6b7e420832b8e7a44baba6fa0a9