### PR TITLE
Remove genres from /list output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,4 @@
 - `/add` now auto-adds only on strict title match and shows clean similar-title dialogs otherwise.
 - `/add` suggestions tighten short-word matching, swap series hints for part requests, and drop the auto-add button from similar dialogs.
 - `/add` now requires a year and shows a dedicated hint when it is missing or invalid.
-- `/list` displays genres for each movie, trimming them to fit Telegram limits.
+  <!-- removed: `/list` no longer displays genres to keep the list clean -->

--- a/src/handlers/list.py
+++ b/src/handlers/list.py
@@ -12,7 +12,6 @@ from src.utils.ids import to_short_id
 from src.movies.constants import icon
 
 TELEGRAM_LIMIT = 4000
-MAX_GENRES_LEN = 60
 
 
 async def list_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -27,16 +26,10 @@ async def list_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             logging.info("/list count_total=0 shown=0")
             return
 
-        lines = []
-        for mid, title, year, status, genres in rows:
-            line = f"{icon(status)} {to_short_id(mid)} — {title} ({year})"
-            if genres:
-                genres = genres.strip()
-                if genres:
-                    if len(genres) > MAX_GENRES_LEN:
-                        genres = genres[: MAX_GENRES_LEN - 1].rstrip() + "…"
-                    line = f"{line} — {genres}"
-            lines.append(line)
+        lines = [
+            f"{icon(status)} {to_short_id(mid)} — {title} ({year})"
+            for (mid, title, year, status, _genres) in rows
+        ]
 
         chunks: list[str] = []
         current = ""


### PR DESCRIPTION
## Summary
- avoid listing genres in `/list` results
- document the removal of genre display

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba080f4d68832ba1e898cfee27bad4