### PR TITLE
Add DATABASE_URL config field

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -27,6 +27,9 @@ class Config:
     # 🔑 Ключ TMDb API. Переменная окружения: TMDB_KEY
     TMDB_KEY: str = os.getenv("TMDB_KEY", "")
 
+    # 🛢️ URL подключения к базе (Postgres). ENV: DATABASE_URL
+    DATABASE_URL: str = os.getenv("DATABASE_URL", "")
+
     # 🌐 Порядок языков по умолчанию (первый — основной). Меняй список при необходимости
     LANG_FALLBACKS: List[str] = field(default_factory=lambda: ["ru", "en"])
 


### PR DESCRIPTION
## Summary
- add `DATABASE_URL` configuration field for Postgres connection

## Testing
- `python -m py_compile src/config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb005c7364832ba0bf6491ddc2fe26