### PR TITLE
fix: correct model env variables and remove unused config fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,10 @@ REQUIRE_PREFIX=true     # true: требовать '.' или '..' в начал
 DEFAULT_PROVIDER=groq    # groq | openai — что использовать без префикса
 
 # модели/токены
-MODEL_DDOT=gpt-4o
-GROQ_MODEL=llama-3.3-70b-versatile
+MODEL_OPENAI=gpt-4o
+MODEL_GROQ=llama-3.3-70b-versatile
 MAX_TOKENS_GROQ=800
-MAX_TOKENS_DDOT=2000
+MAX_TOKENS_OPENAI=2000
 
 PORT=8080
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 | `WEBHOOK_URL` | URL вебхука (опц.) |
 | `WEBHOOK_SECRET` | секрет вебхука (опц.) |
 | `PORT` | порт вебсервера |
-| `MODEL_DDOT` | модель OpenAI |
-| `GROQ_MODEL` | модель Groq |
+| `MODEL_OPENAI` | модель OpenAI |
+| `MODEL_GROQ` | модель Groq |
+| `MAX_TOKENS_OPENAI` | предел токенов для OpenAI |
 | `MAX_TOKENS_GROQ` | предел токенов для Groq |
-| `MAX_TOKENS_DDOT` | предел токенов для OpenAI |
 | `MAX_PROMPT_CHARS` | максимальная длина входного сообщения |
 | `MAX_REPLY_CHARS` | максимальная длина ответа |
 | `REQUIRE_PREFIX` | требовать ли префикс `.`/`..` |

--- a/src/handlers/add_callback.py
+++ b/src/handlers/add_callback.py
@@ -12,7 +12,7 @@ from src.config import config
 from src.i18n import t
 from src.exporter import schedule_export
 from src.utils.ids import to_short_id
-from .add import _pending, NO_DATE, _schedule_auto_delete
+from .add import _pending, NO_DATE
 
 
 async def add_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -48,13 +48,9 @@ async def add_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYP
                 logging.warning(
                     "/add cleanup edit_failed msg_id=%s", query.message.message_id
                 )
-        if config.CLEANUP_NOTICE_SECONDS > 0:
-            notice = await context.bot.send_message(
-                chat_id, t("timeout", lang=lang, query=pending["query"])
-            )
-            _schedule_auto_delete(
-                context.job_queue, chat_id, notice.message_id
-            )
+        await context.bot.send_message(
+            chat_id, t("timeout", lang=lang, query=pending["query"])
+        )
         logging.info(
             "/add cleanup reason=timeout msg_id=%s", query.message.message_id
         )
@@ -83,11 +79,7 @@ async def add_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYP
         logging.info(
             "/add cleanup reason=cancel msg_id=%s", query.message.message_id
         )
-        if config.CLEANUP_NOTICE_SECONDS > 0:
-            notice = await context.bot.send_message(chat_id, t("cancelled", lang=lang))
-            _schedule_auto_delete(
-                context.job_queue, chat_id, notice.message_id
-            )
+        await context.bot.send_message(chat_id, t("cancelled", lang=lang))
         await query.answer()
         return
 
@@ -222,3 +214,4 @@ async def add_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYP
     except Exception:
         logging.exception("export schedule failed")
     await query.answer()
+    return


### PR DESCRIPTION
## Summary
- document MODEL_OPENAI/MODEL_GROQ and their token limits
- drop references to removed cleanup settings
- ensure /add cleanup in callback handler returns cleanly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb0f5f0014832b9fefbdf519681830