### PR TITLE
Move timeouts and limits into config

### DIFF
--- a/src/clients/gpt.py
+++ b/src/clients/gpt.py
@@ -5,6 +5,7 @@ import os
 import requests
 from openai import OpenAI
 
+from src.core.config import config
 from src.utils.text import mask
 
 _client: OpenAI | None = None
@@ -27,41 +28,51 @@ async def ask_openai(
     prompt: str,
     max_tokens: int,
     system: str,
-    timeout: int = 30,
+    timeout: int | None = None,
 ) -> str:
-    def _request() -> str:
-        client = _get_client(api_token)
-        text = ""
-        try:
-            resp = client.responses.create(
-                model=model,
-                input=prompt,
-                instructions=system,
-                max_output_tokens=max_tokens,
-            )
-            text = getattr(resp, "output_text", "") or ""
-            if not text:
-                text = resp.output[0].content[0].text
-        except Exception as e:
-            logging.warning("[openai] responses error %s", mask(str(e)))
-        if not text:
+    timeout = timeout or config.GPT_HTTP_TIMEOUT
+    async def _request() -> str:
+        for attempt in range(config.GPT_MAX_RETRIES):
+            client = _get_client(api_token)
+            text = ""
             try:
-                resp = client.chat.completions.create(
+                resp = await asyncio.to_thread(
+                    client.responses.create,
                     model=model,
-                    messages=[
-                        {"role": "system", "content": system},
-                        {"role": "user", "content": prompt},
-                    ],
-                    max_tokens=max_tokens,
+                    input=prompt,
+                    instructions=system,
+                    max_output_tokens=max_tokens,
                 )
-                text = resp.choices[0].message.content
+                text = getattr(resp, "output_text", "") or ""
+                if not text:
+                    text = resp.output[0].content[0].text
             except Exception as e:
-                logging.error("[openai] chat error %s", mask(str(e)))
-                text = ""
-        return text
+                logging.warning("[openai] responses error %s", mask(str(e)))
+            if not text:
+                try:
+                    resp = await asyncio.to_thread(
+                        client.chat.completions.create,
+                        model=model,
+                        messages=[
+                            {"role": "system", "content": system},
+                            {"role": "user", "content": prompt},
+                        ],
+                        max_tokens=max_tokens,
+                    )
+                    text = resp.choices[0].message.content
+                except Exception as e:
+                    logging.error("[openai] chat error %s", mask(str(e)))
+                    text = ""
+            if text:
+                return text
+            if attempt < config.GPT_MAX_RETRIES - 1:
+                await asyncio.sleep(
+                    config.GPT_RETRY_BACKOFF_BASE * (2 ** attempt)
+                )
+        return ""
 
     try:
-        return await asyncio.wait_for(asyncio.to_thread(_request), timeout)
+        return await asyncio.wait_for(_request(), timeout)
     except Exception as e:
         logging.error("[openai] timeout %s", mask(str(e)))
         return ""
@@ -74,38 +85,46 @@ async def ask_groq(
     prompt: str,
     max_tokens: int,
     system: str,
-    timeout: int = 30,
+    timeout: int | None = None,
 ) -> str:
+    timeout = timeout or config.GPT_HTTP_TIMEOUT
     url = "https://api.groq.com/openai/v1/chat/completions"
 
-    def _request() -> str:
-        try:
-            resp = requests.post(
-                url,
-                headers={"Authorization": f"Bearer {api_token}"},
-                json={
-                    "model": model,
-                    "messages": [
-                        {"role": "system", "content": system},
-                        {"role": "user", "content": prompt},
-                    ],
-                    "max_tokens": max_tokens,
-                },
-                timeout=timeout,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            choice = data.get("choices", [{}])[0]
-            content = choice.get("message", {}).get("content")
-            if not content:
-                content = choice.get("delta", {}).get("content", "")
-            return content or ""
-        except Exception as e:
-            logging.error("[groq] error %s", mask(str(e)))
-            return ""
+    async def _request() -> str:
+        for attempt in range(config.GPT_MAX_RETRIES):
+            try:
+                resp = await asyncio.to_thread(
+                    requests.post,
+                    url,
+                    headers={"Authorization": f"Bearer {api_token}"},
+                    json={
+                        "model": model,
+                        "messages": [
+                            {"role": "system", "content": system},
+                            {"role": "user", "content": prompt},
+                        ],
+                        "max_tokens": max_tokens,
+                    },
+                    timeout=timeout,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                choice = data.get("choices", [{}])[0]
+                content = choice.get("message", {}).get("content")
+                if not content:
+                    content = choice.get("delta", {}).get("content", "")
+                return content or ""
+            except Exception as e:
+                logging.error("[groq] error %s", mask(str(e)))
+                if attempt < config.GPT_MAX_RETRIES - 1:
+                    await asyncio.sleep(
+                        config.GPT_RETRY_BACKOFF_BASE * (2 ** attempt)
+                    )
+        return ""
 
     try:
-        return await asyncio.wait_for(asyncio.to_thread(_request), timeout)
+        return await asyncio.wait_for(_request(), timeout)
     except Exception as e:
         logging.error("[groq] timeout %s", mask(str(e)))
         return ""
+

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -39,6 +39,15 @@ class Config:
     MAX_PROMPT_CHARS: int = _get_int("MAX_PROMPT_CHARS", 2000)  # макс. длина входного текста пользователя
     MAX_REPLY_CHARS: int = _get_int("MAX_REPLY_CHARS", 3500)  # макс. длина ответа, символов
     DIALOG_HISTORY_LEN: int = _get_int("DIALOG_HISTORY_LEN", 5)  # сколько последних сообщений хранить в истории
+    GPT_HTTP_TIMEOUT: int = _get_int(
+        "GPT_HTTP_TIMEOUT", 30
+    )  # таймаут HTTP-запросов к GPT, сек
+    GPT_MAX_RETRIES: int = _get_int(
+        "GPT_MAX_RETRIES", 3
+    )  # макс. попыток запроса к GPT
+    GPT_RETRY_BACKOFF_BASE: int = _get_int(
+        "GPT_RETRY_BACKOFF_BASE", 1
+    )  # базовая задержка между повторными запросами, сек
 
     # --- Вебхук/поллинг ---
     USE_WEBHOOK: bool = _get_bool("USE_WEBHOOK", False)  # режим вебхука: true — вебхук, false — polling
@@ -61,9 +70,15 @@ class Config:
 
     # --- Поведение команд ---
     REQUIRE_PREFIX: bool = _get_bool("REQUIRE_PREFIX", False)  # требовать префикс для обычных сообщений
+    TELEGRAM_MESSAGE_LIMIT: int = _get_int(
+        "TELEGRAM_MESSAGE_LIMIT", 4000
+    )  # макс. длина текста сообщения Telegram, символы
 
     # --- Параметры бота фильмов ---
     LIST_TTL_SECONDS: int = _get_int("LIST_TTL_SECONDS", 300)  # авто-удаление сообщений /list, сек
+    LIST_PAGE_SIZE: int = _get_int(
+        "LIST_PAGE_SIZE", 30
+    )  # сколько последних фильмов показывать командой /list
 
     # --- Параметры команд ---
     ADD_PENDING_TTL: int = _get_int("ADD_PENDING_TTL", 120)  # TTL выбора фильма, сек

--- a/src/handlers/list.py
+++ b/src/handlers/list.py
@@ -11,9 +11,8 @@ from src.utils.text import mask
 from src.utils.ids import to_short_id
 from src.domain.movies.constants import icon
 
-TELEGRAM_LIMIT = 4000
-
-# ⏱ TTL берём из конфига: config.LIST_TTL_SECONDS (секунды авто-удаления /list)
+TELEGRAM_LIMIT = config.TELEGRAM_MESSAGE_LIMIT
+LIST_PAGE_SIZE = config.LIST_PAGE_SIZE
 TTL_SECONDS = config.LIST_TTL_SECONDS
 
 
@@ -42,7 +41,7 @@ async def list_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     chat_id = update.effective_chat.id
     try:
         lang = update.effective_user.language_code or config.LANG_FALLBACKS[0]
-        total, rows = await db.get_last_movies(30)
+        total, rows = await db.get_last_movies(LIST_PAGE_SIZE)
         if total == 0:
             msg = await update.message.reply_text(t("list_empty", lang=lang))
             logging.info("/list count_total=0 shown=0")
@@ -71,7 +70,7 @@ async def list_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             m = await update.message.reply_text(ch)
             sent_ids.append(m.message_id)
 
-        if total > 30:
+        if total > LIST_PAGE_SIZE:
             if config.MEGA_URL:
                 m = await update.message.reply_text(
                     t("list_archive", lang=lang, url=config.MEGA_URL)


### PR DESCRIPTION
## Summary
- centralize Telegram list limits and page size in config
- add GPT HTTP timeout, retry count and backoff configuration
- implement asynchronous retry/backoff for OpenAI and Groq requests

## Testing
- `pytest`
- `python -m py_compile src/clients/gpt.py src/handlers/list.py src/core/config.py src/services/exporter.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3542a114832baa2a8986e70ff7eb