### PR TITLE
Add /done command to mark movies as watched

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from src.handlers.add import add_handler
 from src.handlers.add_callback import add_callback_handler
 from src.handlers.list import list_handler
 from src.handlers.help import help_handler
+from src.handlers.done import done_handler
 from src.core import db
 from src.clients.tmdb import TMDbAuthError, TMDbError, tmdb_client
 from src.utils.text import mask
@@ -110,6 +111,7 @@ def main() -> None:
     app.add_handler(CommandHandler("id", id_handler))
     app.add_handler(CommandHandler("add", add_handler))
     app.add_handler(CommandHandler("list", list_handler))
+    app.add_handler(CommandHandler("done", done_handler))
     app.add_handler(CommandHandler("help", help_handler))
     app.add_handler(CallbackQueryHandler(add_callback_handler, pattern=r"^ADD_"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, gpt_handler))

--- a/src/core/i18n.py
+++ b/src/core/i18n.py
@@ -33,6 +33,13 @@ MESSAGES = {
             "ℹ️ Фильмы ищутся через TMDb.\n"
             "This product uses the TMDb API but is not endorsed or certified by TMDb."
         ),
+        "done_need_id": "Укажи ID фильма, например: /done 1a2b3c",
+        "done_prefix_too_short": "Укажи хотя бы 4 символа ID.",
+        "done_not_found": "Не нашёл фильм с таким ID.",
+        "done_ambiguous": "Несколько совпадений: {sample}",
+        "done_deleted": "Фильм {short_id} — “{title}” удалён.",
+        "done_already": "Фильм {short_id} — “{title}” уже отмечен.",
+        "done_ok": "✅ Просмотрено {short_id}\n🎬 “{title}”",
     },
     "en": {
         "series_prompt": "Looks like it's a series '{base_title}'. Choose a part:",
@@ -55,6 +62,13 @@ MESSAGES = {
         "tmdb_unavailable": "TMDb service is temporarily unavailable, try later.",
         "tech_error": "⚠️ Service temporarily unavailable (id={rid})",
         "same_title_prompt": "Found multiple releases of '{title}'. Pick a year:",
+        "done_need_id": "Specify movie ID, e.g., /done 1a2b3c",
+        "done_prefix_too_short": "Provide at least 4 characters of the ID.",
+        "done_not_found": "Movie not found for this ID.",
+        "done_ambiguous": "Multiple matches: {sample}",
+        "done_deleted": "Movie {short_id} — '{title}' is deleted.",
+        "done_already": "Movie {short_id} — '{title}' already marked as watched.",
+        "done_ok": "✅ Marked as watched {short_id}\n🎬 '{title}'",
     },
 }
 

--- a/src/handlers/done.py
+++ b/src/handlers/done.py
@@ -1,0 +1,103 @@
+import logging
+import uuid
+from typing import Optional
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.core import db
+from src.core.config import config
+from src.core.i18n import t
+from src.domain.movies.constants import STATUS
+from src.utils.ids import to_short_id
+from src.services.exporter import schedule_export
+
+
+def _normalize_id(raw: str) -> str:
+    """
+    Нормализует ID фильма:
+    - убирает пробелы и ведущий '#'
+    - приводит к нижнему регистру
+    """
+    raw = (raw or "").strip().lstrip("#").strip()
+    return raw.lower()
+
+
+async def done_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    Отмечает фильм как «просмотренный».
+    Формат: /done <id|prefix> — принимает полный id или префикс (>=4 символов).
+    """
+    rid = uuid.uuid4().hex[:8].upper()
+    lang = config.LANG_FALLBACKS[0]
+
+    try:
+        args = update.message.get_args() if update.message else ""
+        if not args:
+            await update.message.reply_text(
+                t("done_need_id", lang=lang)  # "Укажи ID фильма, например: /done 1a2b3c"
+            )
+            return
+
+        prefix = _normalize_id(args)
+
+        if len(prefix) < 4:
+            await update.message.reply_text(
+                t("done_prefix_too_short", lang=lang)  # "Укажи хотя бы 4 символа ID."
+            )
+            return
+
+        # Ищем по префиксу (без учёта регистра), исключая удалённые
+        candidates = await db.find_movies_by_id_prefix(prefix, limit=5)
+
+        if not candidates:
+            await update.message.reply_text(t("done_not_found", lang=lang))
+            return
+
+        if len(candidates) > 1:
+            # Несколько совпадений — просим уточнить
+            sample = ", ".join(to_short_id(m["id"]) for m in candidates[:5])
+            await update.message.reply_text(
+                t("done_ambiguous", lang=lang, sample=sample)
+            )
+            return
+
+        movie = candidates[0]
+        mid = movie["id"]
+        title = movie.get("title") or "Без названия"
+        status = movie.get("status")
+
+        if status == STATUS["DELETED"]:
+            await update.message.reply_text(
+                t("done_deleted", lang=lang, title=title, short_id=to_short_id(mid))
+            )
+            return
+
+        if status == STATUS["WATCHED"]:
+            await update.message.reply_text(
+                t("done_already", lang=lang, title=title, short_id=to_short_id(mid))
+            )
+            return
+
+        # Отмечаем как просмотренный
+        updated = await db.mark_movie_watched(mid)
+        short_id = to_short_id(updated["id"])
+        await update.message.reply_text(
+            t("done_ok", lang=lang, title=updated.get("title") or title, short_id=short_id)
+        )
+
+        # Планируем экспорт (дебаунс внутри schedule_export)
+        try:
+            await schedule_export(context.job_queue)
+        except Exception:
+            logging.exception("export schedule failed (/done)")
+
+    except Exception as e:
+        logging.exception("/done rid=%s: %s", rid, e)
+        try:
+            await update.message.reply_text(t("tech_error", lang=lang, rid=rid))
+            log_chat_id = getattr(config, "LOG_CHAT_ID", None)
+            if log_chat_id:
+                await context.bot.send_message(log_chat_id, f"❌ Error {rid}: {e}")
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- implement `/done` command handler to mark movies as watched and schedule exports
- support id prefix search and updating status in database
- add localisation strings and wire handler into application

## Testing
- `pytest -q`
- `python -m py_compile src/handlers/done.py src/core/db.py src/core/i18n.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb5048481c832bb5feb499f75a27bf