### PR TITLE
feat: add DB helpers for done command

### DIFF
--- a/src/handlers/done.py
+++ b/src/handlers/done.py
@@ -32,7 +32,7 @@ async def done_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     try:
         # В PTB v20+ аргументы команды приходят в context.args (list)
-        args = " ".join(context.args).strip() if getattr(context, "args", None) else ""
+        args = " ".join(context.args).strip()
         if not args:
             await update.message.reply_text(
                 t("done_need_id", lang=lang)  # "Укажи ID фильма, например: /done 1a2b3c"


### PR DESCRIPTION
## Summary
- add DB helpers for `/done` command for searching movies by ID prefix and marking movies as watched
- have helpers return dicts and integrate PTB v20 `context.args` for `/done`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb542a71c0832b9e9b9809e10a993e