### PR TITLE
feat: add movie deletion command

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+from importlib import import_module
 
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, CallbackQueryHandler
 
@@ -12,6 +13,7 @@ from src.handlers.list import list_handler
 from src.handlers.help import help_handler
 from src.handlers.done import done_handler
 from src.core import db
+del_handler = import_module("src.handlers.del").del_handler
 from src.clients.tmdb import TMDbAuthError, TMDbError, tmdb_client
 from src.utils.text import mask
 
@@ -112,6 +114,7 @@ def main() -> None:
     app.add_handler(CommandHandler("add", add_handler))
     app.add_handler(CommandHandler("list", list_handler))
     app.add_handler(CommandHandler("done", done_handler))
+    app.add_handler(CommandHandler("del", del_handler))
     app.add_handler(CommandHandler("help", help_handler))
     app.add_handler(CallbackQueryHandler(add_callback_handler, pattern=r"^ADD_"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, gpt_handler))

--- a/src/core/i18n.py
+++ b/src/core/i18n.py
@@ -40,6 +40,12 @@ MESSAGES = {
         "done_deleted": "Фильм {short_id} — “{title}” удалён.",
         "done_already": "Фильм {short_id} — “{title}” уже отмечен.",
         "done_ok": "✅ Просмотрено {short_id}\n🎬 “{title}”",
+        "del_need_id": "Укажи ID фильма, например: /del 1a2b3c",
+        "del_prefix_too_short": "Укажи хотя бы 4 символа ID.",
+        "del_not_found": "Фильм с таким ID не найден.",
+        "del_ambiguous": "Несколько совпадений: {sample}",
+        "del_already": "Фильм {short_id} — “{title}” уже удалён.",
+        "del_ok": "🗑 Удалено {short_id}\n🎬 “{title}”",
     },
     "en": {
         "series_prompt": "Looks like it's a series '{base_title}'. Choose a part:",
@@ -69,6 +75,12 @@ MESSAGES = {
         "done_deleted": "Movie {short_id} — '{title}' is deleted.",
         "done_already": "Movie {short_id} — '{title}' already marked as watched.",
         "done_ok": "✅ Marked as watched {short_id}\n🎬 '{title}'",
+        "del_need_id": "Specify movie ID, e.g., /del 1a2b3c",
+        "del_prefix_too_short": "Provide at least 4 characters of the ID.",
+        "del_not_found": "Movie not found for this ID.",
+        "del_ambiguous": "Multiple matches: {sample}",
+        "del_already": "Movie {short_id} — '{title}' already deleted.",
+        "del_ok": "🗑 Deleted {short_id}\n🎬 '{title}'",
     },
 }
 

--- a/src/handlers/del.py
+++ b/src/handlers/del.py
@@ -1,0 +1,87 @@
+import logging
+import uuid
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from src.core import db
+from src.core.config import config
+from src.core.i18n import t
+from src.domain.movies.constants import STATUS
+from src.utils.ids import to_short_id
+from src.services.exporter import schedule_export
+
+
+def _normalize_id(raw: str) -> str:
+    """
+    Нормализует ID фильма:
+    - убирает пробелы и ведущий '#'
+    - приводит к нижнему регистру
+    """
+    raw = (raw or "").strip().lstrip("#").strip()
+    return raw.lower()
+
+
+async def del_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """
+    Удаляет фильм из списка.
+    Формат: /del <id|prefix> — принимает полный id или префикс (>=4 символов).
+    """
+    rid = uuid.uuid4().hex[:8].upper()
+    lang = config.LANG_FALLBACKS[0]
+
+    try:
+        args = " ".join(context.args).strip()
+        if not args:
+            await update.message.reply_text(t("del_need_id", lang=lang))
+            return
+
+        prefix = _normalize_id(args)
+
+        if len(prefix) < 4:
+            await update.message.reply_text(t("del_prefix_too_short", lang=lang))
+            return
+
+        candidates = await db.find_movies_by_id_prefix(prefix, limit=5, include_deleted=True)
+
+        if not candidates:
+            await update.message.reply_text(t("del_not_found", lang=lang))
+            return
+
+        if len(candidates) > 1:
+            sample = ", ".join(to_short_id(m["id"]) for m in candidates[:5])
+            await update.message.reply_text(t("del_ambiguous", lang=lang, sample=sample))
+            return
+
+        movie = candidates[0]
+        mid = movie["id"]
+        title = movie.get("title") or "Без названия"
+        status = movie.get("status")
+
+        if status == STATUS["DELETED"]:
+            await update.message.reply_text(
+                t("del_already", lang=lang, short_id=to_short_id(mid), title=title)
+            )
+            return
+
+        updated = await db.mark_movie_deleted(mid)
+        short_id = to_short_id(updated["id"])
+        await update.message.reply_text(
+            t("del_ok", lang=lang, title=updated.get("title") or title, short_id=short_id)
+        )
+
+        try:
+            await schedule_export(context.job_queue)
+        except Exception:
+            logging.exception("export schedule failed (/del)")
+
+    except Exception as e:
+        logging.exception("/del rid=%s: %s", rid, e)
+        try:
+            await update.message.reply_text(t("tech_error", lang=lang, rid=rid))
+            log_chat_id = getattr(config, "LOG_CHAT_ID", None)
+            if log_chat_id:
+                await context.bot.send_message(log_chat_id, f"❌ Error {rid}: {e}")
+        except Exception:
+            pass
+


### PR DESCRIPTION
## Summary
- add `/del` handler to remove movies by id
- support marking movies as deleted in database
- extend translations and register `/del` command

## Testing
- `pytest -q`
- `python -m py_compile main.py src/core/db.py src/core/i18n.py src/handlers/del.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb58f09084832b8bbf85bd01510ee4