### PR TITLE
Remove manual updated_at from Instagram link UPSERT

### DIFF
--- a/src/handlers/insta.py
+++ b/src/handlers/insta.py
@@ -11,8 +11,7 @@ INSERT INTO tg_insta_links (chat_id, telegram_user_id, display_name, instagram_u
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (chat_id, telegram_user_id) DO UPDATE
 SET display_name = EXCLUDED.display_name,
-    instagram_username = EXCLUDED.instagram_username,
-    updated_at = NOW()
+    instagram_username = EXCLUDED.instagram_username
 """
 
 # SQL-запрос для получения всех привязок чата


### PR DESCRIPTION
## Summary
- stop manually updating `updated_at` in Instagram link UPSERT query

## Testing
- `python -m py_compile src/handlers/insta.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be11890848832bb4ea4468449a1279