### PR TITLE
refactor: migrate insta handlers to PTB

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from src.handlers.add_callback import add_callback_handler
 from src.handlers.list import list_handler
 from src.handlers.help import help_handler
 from src.handlers.done import done_handler
+from src.handlers.insta import link_handler, insta_handler
 from src.core import db
 del_handler = import_module("src.handlers.del").del_handler
 from src.clients.tmdb import TMDbAuthError, TMDbError, tmdb_client
@@ -116,6 +117,8 @@ def main() -> None:
     app.add_handler(CommandHandler("done", done_handler))
     app.add_handler(CommandHandler("del", del_handler))
     app.add_handler(CommandHandler("help", help_handler))
+    app.add_handler(CommandHandler("link", link_handler))
+    app.add_handler(CommandHandler("insta", insta_handler))
     app.add_handler(CallbackQueryHandler(add_callback_handler, pattern=r"^ADD_"))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, gpt_handler))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ asyncpg>=0.29
 httpx>=0.27
 cachetools>=5.3
 roman>=4.1
-aiogram>=3.0


### PR DESCRIPTION
## Summary
- rewrite /link and /insta handlers to python-telegram-bot
- register new handlers in main
- drop aiogram dependency
- fix messaging and text in insta handlers
- move updated_at comment outside UPSERT SQL string

## Testing
- `python -m py_compile src/handlers/insta.py main.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be1577a9bc832bbeb49a38a7241baa