### PR TITLE
Add optional memory diagnostics for Instagram Reels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,7 @@ PORT=8080
 # logging
 LOG_CHAT_ID=
 LOG_FORMAT=plain  # или json
+MEM_DEBUG=false        # true: включить диагностику памяти
 
 INSTAGRAM_COOKIES_FILE=
 INSTAGRAM_MAX_VIDEO_MB=45

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+import tracemalloc
 from importlib import import_module
 
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, CallbackQueryHandler
@@ -68,6 +69,8 @@ async def on_error(update, context):
 
 def main() -> None:
     _make_logger()
+    if config.MEM_DEBUG:
+        tracemalloc.start()
     async def on_startup(app):
         await db.init()
         try:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -67,6 +67,7 @@ class Config:
     LOG_CHAT_ID: Optional[int] = (
         _get_int("LOG_CHAT_ID", 0) if os.getenv("LOG_CHAT_ID") is not None else None
     )  # чат для ошибок/логов (если задан)
+    MEM_DEBUG: bool = _get_bool("MEM_DEBUG", False)  # диагностировать утечки памяти
 
     # --- Поведение команд ---
     REQUIRE_PREFIX: bool = _get_bool("REQUIRE_PREFIX", False)  # требовать префикс для обычных сообщений


### PR DESCRIPTION
## Summary
- add MEM_DEBUG flag to config
- start tracemalloc when memory debugging is enabled
- log GC, tracemalloc stats and RSS after sending Instagram reels
- clean up oversized files and report memory usage cross-platform

## Testing
- `python -m py_compile main.py src/core/config.py src/handlers/insta_unfurl.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1031e21b8832b8a7e0245e06b70ad