### PR TITLE
Stream Instagram reels to temp files

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -92,6 +92,7 @@ class Config:
     INSTAGRAM_COOKIES_FILE: Optional[str] = os.getenv("INSTAGRAM_COOKIES_FILE") or None  # путь к cookie-файлу
     INSTAGRAM_MAX_VIDEO_MB: int = _get_int("INSTAGRAM_MAX_VIDEO_MB", 45)  # макс. размер ролика, МБ
     INSTAGRAM_ENABLE_UNFURL: bool = _get_bool("INSTAGRAM_ENABLE_UNFURL", True)  # разворачивать ссылки
+    INSTAGRAM_TMP_PREFIX: str = os.getenv("INSTAGRAM_TMP_PREFIX", "igdl_")  # префикс временных директорий
 
 
 config = Config()


### PR DESCRIPTION
## Summary
- stream Instagram reels directly to temporary directory with yt_dlp
- disable yt_dlp cache and part files; ensure mp4 output and ffmpeg usage
- add configurable temp prefix for Instagram downloads
- clean up temporary directories after sending or size errors; return path only if mp4 exists

## Testing
- `python -m py_compile src/handlers/insta_unfurl.py src/services/ig_reels.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1064ac4ec832bbc62c15963dd7596